### PR TITLE
Add bidirectional navigation between inspector and server details

### DIFF
--- a/apps/frontend/app/[locale]/(sidebar)/mcp-inspector/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-inspector/page.tsx
@@ -2,7 +2,7 @@
 
 import { McpServer, McpServerTypeEnum } from "@repo/zod-types";
 import { useMemoizedFn } from "ahooks";
-import { ChevronDown, Edit, SearchCode, Server } from "lucide-react";
+import { ChevronDown, Edit, Eye, SearchCode, Server } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { Suspense, useMemo, useState } from "react";
 
@@ -266,6 +266,16 @@ function McpInspectorContent() {
                 {connection.connectionStatus === "connected"
                   ? t("inspector:reconnectButton")
                   : t("inspector:connectButton")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  router.push(`/mcp-servers/${selectedServerUuid}`)
+                }
+              >
+                <Eye className="h-4 w-4 mr-2" />
+                {t("mcp-servers:list.viewDetails")}
               </Button>
               <Button
                 variant="outline"

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/[uuid]/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/[uuid]/page.tsx
@@ -5,7 +5,15 @@ import {
   McpServerErrorStatusEnum,
   McpServerTypeEnum,
 } from "@repo/zod-types";
-import { ArrowLeft, Edit, Eye, EyeOff, Plug, Server } from "lucide-react";
+import {
+  ArrowLeft,
+  Edit,
+  Eye,
+  EyeOff,
+  Plug,
+  SearchCode,
+  Server,
+} from "lucide-react";
 import Link from "next/link";
 import { notFound, useRouter } from "next/navigation";
 import { use, useEffect, useState } from "react";
@@ -314,6 +322,16 @@ export default function McpServerDetailPage({
           </Button>
         </Link>
         <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              router.push(`/mcp-inspector?server=${encodeURIComponent(uuid)}`)
+            }
+          >
+            <SearchCode className="h-4 w-4 mr-2" />
+            {t("mcp-servers:list.inspect")}
+          </Button>
           <Button
             variant="outline"
             size="sm"


### PR DESCRIPTION
This PR adds 2 buttons to make it easy to jump between the inspector & server detail pages. 

### Inspector Page

<img width="1138" height="335" alt="image" src="https://github.com/user-attachments/assets/63c5bbe7-dd2d-4847-95be-4e2dc937c007" />

### Server Details Page

<img width="1154" height="468" alt="image" src="https://github.com/user-attachments/assets/5aa638ce-93d5-4390-8b55-27a4cab68dde" />
