### PR TITLE
Add SSL/certificate and proxy env vars to default whitelist

### DIFF
--- a/apps/backend/src/lib/metamcp/utils.ts
+++ b/apps/backend/src/lib/metamcp/utils.ts
@@ -21,7 +21,32 @@ export const DEFAULT_INHERITED_ENV_VARS =
         "USERPROFILE",
       ]
     : /* list inspired by the default env inheritance of sudo */
-      ["HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER"];
+      [
+        "HOME",
+        "LOGNAME",
+        "PATH",
+        "SHELL",
+        "TERM",
+        "USER",
+        // SSL/Certificate variables for corporate proxies and custom CA certificates
+        "NODE_EXTRA_CA_CERTS",
+        "NODE_TLS_REJECT_UNAUTHORIZED",
+        "SSL_CERT_FILE",
+        "CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "REQUESTS_CERT_FILE",
+        "CURL_CA_BUNDLE",
+        "PIP_CERT",
+        "UV_CERT",
+        "PYTHONHTTPSVERIFY",
+        // Proxy variables
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+      ];
 
 /**
  * Returns a default environment object including only environment variables deemed safe to inherit.

--- a/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
+++ b/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
@@ -61,7 +61,32 @@ export const DEFAULT_INHERITED_ENV_VARS =
         "PROGRAMFILES",
       ]
     : /* list inspired by the default env inheritance of sudo */
-      ["HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER"];
+      [
+        "HOME",
+        "LOGNAME",
+        "PATH",
+        "SHELL",
+        "TERM",
+        "USER",
+        // SSL/Certificate variables for corporate proxies and custom CA certificates
+        "NODE_EXTRA_CA_CERTS",
+        "NODE_TLS_REJECT_UNAUTHORIZED",
+        "SSL_CERT_FILE",
+        "CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "REQUESTS_CERT_FILE",
+        "CURL_CA_BUNDLE",
+        "PIP_CERT",
+        "UV_CERT",
+        "PYTHONHTTPSVERIFY",
+        // Proxy variables
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+      ];
 
 /**
  * Returns a default environment object including only environment variables deemed safe to inherit.


### PR DESCRIPTION
  Fixes spawned processes (npx, uvx, pip) failing with SSL errors
  in corporate proxy & firewall environments with custom CA signing certificates.

**Root cause:** `getDefaultEnvironment()` whitelists only basic env vars (`HOME`, `PATH`, `SHELL`, etc.) and filters out SSL/proxy variables.

  Added to whitelist:
  - SSL/certificate vars: NODE_EXTRA_CA_CERTS, SSL_CERT_FILE, etc.
  - Python-specific: REQUESTS_CA_BUNDLE, PIP_CERT, UV_CERT, etc.
  - Proxy vars: HTTP_PROXY, HTTPS_PROXY, NO_PROXY (both cases)

**Affected files:**
- `apps/backend/src/lib/stdio-transport/process-managed-transport.ts:47-64`
- `apps/backend/src/lib/metamcp/utils.ts:8-24`
  
  ## Use Cases

- Palo Alto Networks SSL inspection
- Zscaler cloud proxy
- Cisco Firepower/Blue Coat proxies
- Any corporate environment with custom CA certificates