### PR TITLE
fix: prevent process accumulation on connection failures

### DIFF
--- a/apps/backend/src/lib/metamcp/client.ts
+++ b/apps/backend/src/lib/metamcp/client.ts
@@ -175,6 +175,9 @@ export const connectMetaMcpClient = async (
   );
 
   while (retry) {
+    let transport: Transport | undefined;
+    let client: Client | undefined;
+
     try {
       // Check if server is already in error state before attempting connection
       const isInErrorState = await serverErrorTracker.isServerInErrorState(
@@ -188,7 +191,10 @@ export const connectMetaMcpClient = async (
       }
 
       // Create fresh client and transport for each attempt
-      const { client, transport } = createMetaMcpClient(serverParams);
+      const result = createMetaMcpClient(serverParams);
+      client = result.client;
+      transport = result.transport;
+
       if (!client || !transport) {
         return undefined;
       }
@@ -222,8 +228,8 @@ export const connectMetaMcpClient = async (
       return {
         client,
         cleanup: async () => {
-          await transport.close();
-          await client.close();
+          await transport!.close();
+          await client!.close();
         },
         onProcessCrash: (exitCode, signal) => {
           console.warn(
@@ -243,6 +249,30 @@ export const connectMetaMcpClient = async (
         `Error connecting to MetaMCP client (attempt ${count + 1}/${maxAttempts})`,
         error,
       );
+
+      // CRITICAL FIX: Clean up transport/process on connection failure
+      // This prevents orphaned processes from accumulating
+      if (transport) {
+        try {
+          await transport.close();
+          console.log(
+            `Cleaned up transport for failed connection to ${serverParams.name} (${serverParams.uuid})`,
+          );
+        } catch (cleanupError) {
+          console.error(
+            `Error cleaning up transport for ${serverParams.name} (${serverParams.uuid}):`,
+            cleanupError,
+          );
+        }
+      }
+      if (client) {
+        try {
+          await client.close();
+        } catch (cleanupError) {
+          // Client may not be fully initialized, ignore
+        }
+      }
+
       count++;
       retry = count < maxAttempts;
       if (retry) {


### PR DESCRIPTION
Key changes:
- Clean up transport/process when connection attempts fail in client.ts This prevents orphaned STDIO processes from accumulating when MCP servers fail to connect (timeouts, 401s, etc.)

- Add connection limit (maxTotalConnections=100) to mcp-server-pool.ts Prevents runaway process spawning under error conditions

- Add getTotalConnectionCount() and canCreateConnection() helpers Tracks idle + active + pending connections to enforce limits

Fixes the issue where repeated connection failures to MCP servers would spawn processes that never got cleaned up, eventually exhausting system resources.