### PR TITLE
feat: add EXTRA_TRUSTED_ORIGINS env var for configurable trusted origins

### DIFF
--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -49,6 +49,28 @@ if (process.env.OIDC_CLIENT_ID && process.env.OIDC_CLIENT_SECRET) {
   console.log(`✓ OIDC Provider configured: ${oidcConfig.providerId}`);
 }
 
+// Default trusted origins for development
+const DEFAULT_TRUSTED_ORIGINS = [
+  "http://localhost",
+  "http://localhost:3000",
+  "http://localhost:12008",
+  "http://127.0.0.1",
+  "http://127.0.0.1:12008",
+  "http://127.0.0.1:3000",
+  "http://0.0.0.0",
+  "http://0.0.0.0:3000",
+  "http://0.0.0.0:12008",
+];
+
+// Parse extra trusted origins from environment variable (comma-separated)
+const extraTrustedOrigins = process.env.EXTRA_TRUSTED_ORIGINS
+  ? process.env.EXTRA_TRUSTED_ORIGINS.split(",")
+      .map((origin: string) => origin.trim())
+      .filter(Boolean)
+  : [];
+
+const trustedOrigins = [...DEFAULT_TRUSTED_ORIGINS, ...extraTrustedOrigins];
+
 export const auth = betterAuth({
   secret: BETTER_AUTH_SECRET,
   baseURL: BETTER_AUTH_URL,
@@ -61,17 +83,7 @@ export const auth = betterAuth({
       verification: schema.verificationsTable,
     },
   }),
-  trustedOrigins: [
-    "http://localhost", // Added this line to fix the "Invalid origin" error
-    "http://localhost:3000",
-    "http://localhost:12008",
-    "http://127.0.0.1", // Also added this for good measure
-    "http://127.0.0.1:12008",
-    "http://127.0.0.1:3000",
-    "http://0.0.0.0",
-    "http://0.0.0.0:3000",
-    "http://0.0.0.0:12008",
-  ],
+  trustedOrigins,
   plugins: [
     // Add generic OAuth plugin for OIDC support
     ...(oidcProviders.length > 0

--- a/example.env
+++ b/example.env
@@ -34,3 +34,7 @@ BETTER_AUTH_SECRET=your-super-secret-key-change-this-in-production
 
 # Docker networking fix
 TRANSFORM_LOCALHOST_TO_DOCKER_INTERNAL=true
+
+# Extra trusted origins for Better Auth (comma-separated)
+# Useful for cluster deployments where different ports/origins are needed
+# EXTRA_TRUSTED_ORIGINS=http://myapp.example.com,http://myapp.example.com:8080

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,8 @@
     "OIDC_PROVIDER_ID",
     "TRANSFORM_LOCALHOST_TO_DOCKER_INTERNAL",
     "NODE_ENV",
-    "POSTGRES_CA_CERT"
+    "POSTGRES_CA_CERT",
+    "EXTRA_TRUSTED_ORIGINS"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Add `EXTRA_TRUSTED_ORIGINS` environment variable to configure additional trusted origins for Better Auth
- Parses comma-separated origins and merges with default localhost origins
- Useful for cluster deployments where different ports/origins are needed

## Changes
- `apps/backend/src/auth.ts`: Parse and merge extra trusted origins from env var
- `turbo.json`: Add new env var to globalEnv
- `example.env`: Add documentation for the new variable

## Usage
```bash
# Set additional trusted origins (comma-separated)
EXTRA_TRUSTED_ORIGINS=http://myapp.example.com,http://myapp.example.com:8080
```

## Test
- Set `EXTRA_TRUSTED_ORIGINS` env var with custom origins
- Verify authentication works from those origins
- Verify default localhost origins still work