### PR TITLE
fix: touch session timestamps on access for idle-based cleanup

### DIFF
--- a/apps/backend/src/db/repositories/mcp-servers.repo.ts
+++ b/apps/backend/src/db/repositories/mcp-servers.repo.ts
@@ -248,6 +248,22 @@ export class McpServersRepository {
 
     return updatedServer;
   }
+
+  /**
+   * Reset error_status to NONE for all servers that are currently in ERROR state.
+   * Used on startup to give servers a fresh chance.
+   */
+  async resetAllErrorStatuses(): Promise<number> {
+    const updated = await db
+      .update(mcpServersTable)
+      .set({
+        error_status: McpServerErrorStatusEnum.Enum.NONE,
+      })
+      .where(eq(mcpServersTable.error_status, McpServerErrorStatusEnum.Enum.ERROR))
+      .returning();
+
+    return updated.length;
+  }
 }
 
 export const mcpServersRepository = new McpServersRepository();

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -114,6 +114,29 @@ start().catch((err) => {
   // Do not throw - keep consistent with other startup behavior
 });
 
+// Graceful shutdown: clean up MCP server pools on SIGTERM/SIGINT
+// Prevents orphaned STDIO child processes when backend restarts
+const gracefulShutdown = async (signal: string) => {
+  console.log(`${signal} received, cleaning up MCP server pools...`);
+  try {
+    const { mcpServerPool } = await import("./lib/metamcp");
+    const { metaMcpServerPool } = await import(
+      "./lib/metamcp/metamcp-server-pool"
+    );
+    await Promise.allSettled([
+      mcpServerPool.cleanupAll(),
+      metaMcpServerPool.cleanupAll(),
+    ]);
+    console.log("MCP server pools cleaned up successfully");
+  } catch (error) {
+    console.error("Error during graceful shutdown:", error);
+  }
+  process.exit(0);
+};
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+
 app.get("/health", (req, res) => {
   res.json({
     status: "ok",

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -95,7 +95,7 @@ export const configService = {
     const config = await configRepo.getConfig(
       ConfigKeyEnum.Enum.MCP_MAX_ATTEMPTS,
     );
-    return config?.value ? parseInt(config.value, 10) : 1;
+    return config?.value ? parseInt(config.value, 10) : 3;
   },
 
   async setMcpMaxAttempts(maxAttempts: number): Promise<void> {

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -11,6 +11,8 @@ export interface McpServerPoolStatus {
   active: number;
   activeSessionIds: string[];
   idleServerUuids: string[];
+  perServerCounts?: Record<string, number>;
+  maxConnectionsPerServer?: number;
 }
 
 export class McpServerPool {
@@ -50,12 +52,17 @@ export class McpServerPool {
   // Maximum total connections (idle + active) to prevent runaway process spawning
   private readonly maxTotalConnections: number;
 
+  // Maximum connections per individual server UUID (prevents per-server process explosion)
+  private readonly maxConnectionsPerServer: number;
+
   private constructor(
     defaultIdleCount: number = 1,
     maxTotalConnections: number = 100,
+    maxConnectionsPerServer: number = 5,
   ) {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;
+    this.maxConnectionsPerServer = maxConnectionsPerServer;
     this.startCleanupTimer();
     this.startHealthCheckTimer();
   }
@@ -63,11 +70,85 @@ export class McpServerPool {
   /**
    * Get the singleton instance
    */
-  static getInstance(defaultIdleCount: number = 1): McpServerPool {
+  static getInstance(
+    defaultIdleCount: number = 1,
+    maxConnectionsPerServer: number = 5,
+  ): McpServerPool {
     if (!McpServerPool.instance) {
-      McpServerPool.instance = new McpServerPool(defaultIdleCount);
+      McpServerPool.instance = new McpServerPool(
+        defaultIdleCount,
+        100,
+        maxConnectionsPerServer,
+      );
     }
     return McpServerPool.instance;
+  }
+
+  /**
+   * Count all connections (idle + active + pending) for a specific server UUID
+   */
+  private countConnectionsForServer(serverUuid: string): number {
+    let count = 0;
+
+    // Count idle session
+    if (this.idleSessions[serverUuid]) {
+      count += 1;
+    }
+
+    // Count active sessions across all sessionIds
+    for (const sessionServers of Object.values(this.activeSessions)) {
+      if (sessionServers[serverUuid]) {
+        count += 1;
+      }
+    }
+
+    // Count pending idle creation
+    if (this.creatingIdleSessions.has(serverUuid)) {
+      count += 1;
+    }
+
+    return count;
+  }
+
+  /**
+   * Check if we can create another connection for a specific server
+   */
+  private canCreateConnectionForServer(serverUuid: string): boolean {
+    const count = this.countConnectionsForServer(serverUuid);
+    if (count >= this.maxConnectionsPerServer) {
+      logger.warn(
+        `Per-server connection limit reached for ${serverUuid}: ${count}/${this.maxConnectionsPerServer}`,
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Find the oldest active connection for a server UUID (for reuse when at cap)
+   */
+  private findOldestActiveConnectionForServer(
+    serverUuid: string,
+  ): ConnectedClient | undefined {
+    let oldestSessionId: string | undefined;
+    let oldestTimestamp = Infinity;
+
+    for (const [sessionId, sessionServers] of Object.entries(
+      this.activeSessions,
+    )) {
+      if (sessionServers[serverUuid]) {
+        const timestamp = this.sessionTimestamps[sessionId] || Infinity;
+        if (timestamp < oldestTimestamp) {
+          oldestTimestamp = timestamp;
+          oldestSessionId = sessionId;
+        }
+      }
+    }
+
+    if (oldestSessionId) {
+      return this.activeSessions[oldestSessionId]?.[serverUuid];
+    }
+    return undefined;
   }
 
   /**
@@ -114,7 +195,20 @@ export class McpServerPool {
       return idleClient;
     }
 
-    // No idle session available, create a new connection
+    // No idle session available — check per-server cap before spawning
+    if (!this.canCreateConnectionForServer(serverUuid)) {
+      // At cap: reuse the oldest active connection instead of spawning
+      const reusable = this.findOldestActiveConnectionForServer(serverUuid);
+      if (reusable) {
+        logger.info(
+          `Reusing existing connection for server ${serverUuid} (at per-server cap ${this.maxConnectionsPerServer})`,
+        );
+        this.activeSessions[sessionId][serverUuid] = reusable;
+        this.sessionToServers[sessionId].add(serverUuid);
+        return reusable;
+      }
+    }
+
     const newClient = await this.createNewConnection(params, namespaceUuid);
     if (!newClient) {
       return undefined;
@@ -208,6 +302,11 @@ export class McpServerPool {
       return;
     }
 
+    // Don't create if at per-server cap
+    if (!this.canCreateConnectionForServer(serverUuid)) {
+      return;
+    }
+
     const newClient = await this.createNewConnection(params, namespaceUuid);
     if (newClient) {
       this.idleSessions[serverUuid] = newClient;
@@ -228,6 +327,11 @@ export class McpServerPool {
       this.idleSessions[serverUuid] ||
       this.creatingIdleSessions.has(serverUuid)
     ) {
+      return;
+    }
+
+    // Check per-server cap before spawning a background idle
+    if (!this.canCreateConnectionForServer(serverUuid)) {
       return;
     }
 
@@ -389,11 +493,20 @@ export class McpServerPool {
       0,
     );
 
+    // Calculate per-server breakdown
+    const perServerCounts: Record<string, number> = {};
+    for (const serverUuid of Object.keys(this.serverParamsCache)) {
+      perServerCounts[serverUuid] =
+        this.countConnectionsForServer(serverUuid);
+    }
+
     return {
       idle,
       active,
       activeSessionIds: Object.keys(this.activeSessions),
       idleServerUuids: Object.keys(this.idleSessions),
+      perServerCounts,
+      maxConnectionsPerServer: this.maxConnectionsPerServer,
     };
   }
 

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -38,6 +38,9 @@ export class McpServerPool {
   // Session cleanup timer
   private cleanupTimer: NodeJS.Timeout | null = null;
 
+  // Health check timer for idle sessions
+  private healthCheckTimer: NodeJS.Timeout | null = null;
+
   // Background idle sessions by namespace: namespaceUuid -> any
   private backgroundIdleSessionsByNamespace: Map<string, any> = new Map();
 
@@ -54,6 +57,7 @@ export class McpServerPool {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;
     this.startCleanupTimer();
+    this.startHealthCheckTimer();
   }
 
   /**
@@ -80,6 +84,8 @@ export class McpServerPool {
 
     // Check if we already have an active session for this sessionId and server
     if (this.activeSessions[sessionId]?.[serverUuid]) {
+      // Touch timestamp on every access so SESSION_LIFETIME acts as idle timeout, not hard TTL
+      this.sessionTimestamps[sessionId] = Date.now();
       return this.activeSessions[sessionId][serverUuid];
     }
 
@@ -283,7 +289,8 @@ export class McpServerPool {
   }
 
   /**
-   * Cleanup a session by sessionId
+   * Cleanup a session by sessionId.
+   * Recycles healthy connections back to the idle pool instead of destroying them.
    */
   async cleanupSession(sessionId: string): Promise<void> {
     const activeSession = this.activeSessions[sessionId];
@@ -291,12 +298,31 @@ export class McpServerPool {
       return;
     }
 
-    // Cleanup all connections for this session
-    await Promise.allSettled(
-      Object.entries(activeSession).map(async ([_serverUuid, client]) => {
-        await client.cleanup();
-      }),
-    );
+    let recycled = 0;
+    let destroyed = 0;
+
+    // Try to recycle each connection back to idle pool
+    for (const [serverUuid, client] of Object.entries(activeSession)) {
+      if (!this.idleSessions[serverUuid]) {
+        // No idle session for this server — recycle the connection
+        this.idleSessions[serverUuid] = client;
+        recycled++;
+        logger.info(
+          `Recycled active connection for server ${serverUuid} to idle pool (session ${sessionId})`,
+        );
+      } else {
+        // Already have an idle session — destroy the extra
+        try {
+          await client.cleanup();
+        } catch (error) {
+          logger.error(
+            `Error cleaning up extra connection for server ${serverUuid}:`,
+            error,
+          );
+        }
+        destroyed++;
+      }
+    }
 
     // Remove from active sessions
     delete this.activeSessions[sessionId];
@@ -305,22 +331,11 @@ export class McpServerPool {
     delete this.sessionTimestamps[sessionId];
 
     // Clean up session to servers mapping
-    const serverUuids = this.sessionToServers[sessionId];
-    if (serverUuids) {
-      // For each server this session was using, create new idle sessions if needed (ASYNC - NON-BLOCKING)
-      Array.from(serverUuids).forEach((serverUuid) => {
-        const params = this.serverParamsCache[serverUuid];
-        if (params) {
-          // Note: We don't have namespaceUuid here, so we can't track crashes properly
-          // This is a limitation of the current design - we'll need to pass namespaceUuid from the caller
-          this.createIdleSessionAsync(serverUuid, params);
-        }
-      });
+    delete this.sessionToServers[sessionId];
 
-      delete this.sessionToServers[sessionId];
-    }
-
-    logger.info(`Cleaned up MCP server pool session ${sessionId}`);
+    logger.info(
+      `Cleaned up session ${sessionId} (recycled: ${recycled}, destroyed: ${destroyed})`,
+    );
   }
 
   /**
@@ -352,6 +367,12 @@ export class McpServerPool {
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
+    }
+
+    // Clear health check timer
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = null;
     }
 
     logger.info("Cleaned up all MCP server pool sessions");
@@ -692,6 +713,79 @@ export class McpServerPool {
       }
     } catch (error) {
       logger.error("Error during automatic session cleanup:", error);
+    }
+  }
+
+  /**
+   * Start the health check timer for idle sessions
+   */
+  private startHealthCheckTimer(): void {
+    // Check idle session health every 60 seconds
+    this.healthCheckTimer = setInterval(
+      async () => {
+        await this.checkIdleSessionHealth();
+      },
+      60 * 1000,
+    ); // 60 seconds
+  }
+
+  /**
+   * Check health of idle sessions by pinging them.
+   * Dead sessions are cleaned up and recreated.
+   * Servers in ERROR state whose crash counters have been reset are retried.
+   */
+  private async checkIdleSessionHealth(): Promise<void> {
+    const serverUuids = Object.keys(this.idleSessions);
+    if (serverUuids.length === 0) {
+      return;
+    }
+
+    for (const serverUuid of serverUuids) {
+      const client = this.idleSessions[serverUuid];
+      if (!client) continue;
+
+      try {
+        // Ping with a 5-second timeout
+        await client.client.ping({ timeout: 5000 });
+      } catch {
+        logger.warn(
+          `Idle session health check failed for server ${serverUuid}, recreating...`,
+        );
+
+        // Clean up the dead session
+        try {
+          await client.cleanup();
+        } catch {
+          // Already dead, ignore cleanup errors
+        }
+        delete this.idleSessions[serverUuid];
+
+        // Reset error state so we can retry
+        await serverErrorTracker.resetServerErrorState(serverUuid);
+
+        // Recreate if we have cached params
+        const params = this.serverParamsCache[serverUuid];
+        if (params) {
+          this.createIdleSessionAsync(serverUuid, params);
+        }
+      }
+    }
+
+    // Also check for servers in ERROR state that have cached params but no idle session.
+    // If they were reset (e.g., on startup), we should try to recreate them.
+    for (const [serverUuid, params] of Object.entries(this.serverParamsCache)) {
+      if (
+        !this.idleSessions[serverUuid] &&
+        !this.creatingIdleSessions.has(serverUuid)
+      ) {
+        const isError = await serverErrorTracker.isServerInErrorState(
+          serverUuid,
+        );
+        if (!isError) {
+          // Not in error and no idle session - try to create one
+          this.createIdleSessionAsync(serverUuid, params);
+        }
+      }
     }
   }
 

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -167,6 +167,28 @@ export const createServer = async (
       `[DEBUG-TOOLS] 📋 Processing ${allServerEntries.length} servers`,
     );
 
+    // Cold-start warmup: if pool has 0 idle + 0 active sessions but servers
+    // exist in DB, trigger a blocking warmup before tools/list responds.
+    // This prevents 0-tool responses after idle timeout expires all connections.
+    const poolStatus = mcpServerPool.getPoolStatus();
+    if (
+      poolStatus.idle === 0 &&
+      poolStatus.active === 0 &&
+      allServerEntries.length > 0
+    ) {
+      console.log(
+        `[DEBUG-TOOLS] ⚠️ Cold start: 0 idle, 0 active sessions but ${allServerEntries.length} servers registered. Warming up...`,
+      );
+      for (const [uuid] of allServerEntries) {
+        await mcpServerPool.resetServerErrorState(uuid);
+      }
+      await mcpServerPool.ensureIdleSessions(serverParams, namespaceUuid);
+      const afterStatus = mcpServerPool.getPoolStatus();
+      console.log(
+        `[DEBUG-TOOLS] ✅ Pool warmup complete: ${afterStatus.idle} idle, ${afterStatus.active} active`,
+      );
+    }
+
     await Promise.allSettled(
       allServerEntries.map(async ([mcpServerUuid, params]) => {
         console.log(`[DEBUG-TOOLS] 🔧 Server: ${params.name || mcpServerUuid}`);

--- a/apps/backend/src/lib/metamcp/server-error-tracker.ts
+++ b/apps/backend/src/lib/metamcp/server-error-tracker.ts
@@ -19,7 +19,7 @@ export class ServerErrorTracker {
   private crashAttempts: Map<string, number> = new Map();
 
   // Default max attempts before marking as ERROR (fallback if config is not available)
-  private readonly fallbackMaxAttempts: number = 1;
+  private readonly fallbackMaxAttempts: number = 3;
 
   // Server-specific max attempts (can be configured per server)
   private serverMaxAttempts: Map<string, number> = new Map();
@@ -134,6 +134,13 @@ export class ServerErrorTracker {
    */
   resetServerAttempts(serverUuid: string): void {
     this.crashAttempts.delete(serverUuid);
+  }
+
+  /**
+   * Reset all crash attempts (e.g., on startup for a clean slate)
+   */
+  resetAllAttempts(): void {
+    this.crashAttempts.clear();
   }
 
   /**

--- a/apps/backend/src/lib/startup.ts
+++ b/apps/backend/src/lib/startup.ts
@@ -3,6 +3,7 @@ import { ServerParameters } from "@repo/zod-types";
 import { mcpServersRepository, namespacesRepository } from "../db/repositories";
 import { initializeEnvironmentConfiguration } from "./bootstrap.service";
 import { metaMcpServerPool } from "./metamcp";
+import { serverErrorTracker } from "./metamcp/server-error-tracker";
 import { convertDbServerToParams } from "./metamcp/utils";
 
 /**
@@ -47,6 +48,16 @@ export async function initializeIdleServers() {
     console.log(
       "Initializing idle servers for all namespaces and all MCP servers...",
     );
+
+    // Reset all ERROR statuses so servers get a fresh chance on restart
+    const resetCount = await mcpServersRepository.resetAllErrorStatuses();
+    if (resetCount > 0) {
+      console.log(
+        `Reset ${resetCount} server(s) from ERROR to NONE status on startup`,
+      );
+    }
+    // Also clear in-memory crash attempt counters
+    serverErrorTracker.resetAllAttempts();
 
     // Fetch all namespaces from the database
     const namespaces = await namespacesRepository.findAll();

--- a/apps/backend/src/routers/public-metamcp.ts
+++ b/apps/backend/src/routers/public-metamcp.ts
@@ -5,6 +5,7 @@ import logger from "@/utils/logger";
 
 import { endpointsRepository } from "../db/repositories/endpoints.repo";
 import { openApiRouter } from "./public-metamcp/openapi";
+import adminRouter from "./public-metamcp/admin";
 import sseRouter from "./public-metamcp/sse";
 import streamableHttpRouter from "./public-metamcp/streamable-http";
 
@@ -42,6 +43,9 @@ publicEndpointsRouter.use(sseRouter);
 
 // Use OpenAPI router for /api and /openapi.json routes
 publicEndpointsRouter.use(openApiRouter);
+
+// Use Admin router for /admin endpoints (error reset, diagnostics)
+publicEndpointsRouter.use(adminRouter);
 
 // Health check endpoint
 publicEndpointsRouter.get("/health", (req, res) => {

--- a/apps/backend/src/routers/public-metamcp/admin.ts
+++ b/apps/backend/src/routers/public-metamcp/admin.ts
@@ -1,0 +1,129 @@
+import express from "express";
+
+import {
+  ApiKeyAuthenticatedRequest,
+  authenticateApiKey,
+} from "@/middleware/api-key-oauth.middleware";
+import { lookupEndpoint } from "@/middleware/lookup-endpoint-middleware";
+import logger from "@/utils/logger";
+
+import { mcpServersRepository } from "../../db/repositories";
+import { serverErrorTracker } from "../../lib/metamcp/server-error-tracker";
+import { initializeIdleServers } from "../../lib/startup";
+
+const adminRouter = express.Router();
+
+// JSON body parser for admin routes
+adminRouter.use(express.json());
+
+/**
+ * POST /metamcp/admin/reset-errors
+ *
+ * Resets ERROR state for MCP servers without requiring a full backend restart.
+ * Optionally targets a specific server by UUID, or resets all if no UUID given.
+ *
+ * Body: { "serverUuid": "optional-specific-uuid" }
+ * Auth: Same API key as MCP endpoints (X-API-Key header)
+ */
+adminRouter.post(
+  "/:endpoint_name/admin/reset-errors",
+  lookupEndpoint,
+  authenticateApiKey,
+  async (req: ApiKeyAuthenticatedRequest, res) => {
+    try {
+      const { serverUuid } = req.body || {};
+      const resetResults: string[] = [];
+
+      if (serverUuid) {
+        // Reset specific server
+        await serverErrorTracker.resetServerErrorState(serverUuid);
+        resetResults.push(serverUuid);
+        logger.info(
+          `Admin API: Reset error state for server ${serverUuid}`,
+        );
+      } else {
+        // Reset all servers in ERROR state
+        const allServers = await mcpServersRepository.findAll();
+        const errorServers = allServers.filter(
+          (s) => s.error_status === "ERROR",
+        );
+
+        for (const server of errorServers) {
+          await serverErrorTracker.resetServerErrorState(server.uuid);
+          resetResults.push(server.name || server.uuid);
+        }
+
+        // Also clear all in-memory crash counters
+        serverErrorTracker.resetAllAttempts();
+
+        logger.info(
+          `Admin API: Reset ${resetResults.length} servers from ERROR state: ${resetResults.join(", ")}`,
+        );
+      }
+
+      // Trigger idle server re-initialization to respawn connections
+      // Run async — don't block the response
+      initializeIdleServers().catch((err) => {
+        logger.error("Admin API: Error re-initializing idle servers:", err);
+      });
+
+      res.json({
+        success: true,
+        reset: resetResults.length,
+        servers: resetResults,
+        message:
+          resetResults.length > 0
+            ? `Reset ${resetResults.length} server(s). Idle session re-initialization triggered.`
+            : "No servers were in ERROR state.",
+      });
+    } catch (error) {
+      logger.error("Admin API: Error resetting server errors:", error);
+      res.status(500).json({
+        success: false,
+        error: "Failed to reset server errors",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+);
+
+/**
+ * GET /metamcp/admin/error-status
+ *
+ * Returns current error status of all servers (for diagnostics).
+ */
+adminRouter.get(
+  "/:endpoint_name/admin/error-status",
+  lookupEndpoint,
+  authenticateApiKey,
+  async (req: ApiKeyAuthenticatedRequest, res) => {
+    try {
+      const allServers = await mcpServersRepository.findAll();
+      const serverStatuses = allServers.map((s) => ({
+        uuid: s.uuid,
+        name: s.name,
+        error_status: s.error_status,
+        attempts: serverErrorTracker.getServerAttempts(s.uuid),
+      }));
+
+      const errorCount = serverStatuses.filter(
+        (s) => s.error_status === "ERROR",
+      ).length;
+
+      res.json({
+        timestamp: new Date().toISOString(),
+        total: serverStatuses.length,
+        errored: errorCount,
+        servers: serverStatuses,
+      });
+    } catch (error) {
+      logger.error("Admin API: Error fetching server statuses:", error);
+      res.status(500).json({
+        success: false,
+        error: "Failed to fetch server statuses",
+      });
+    }
+  },
+);
+
+export default adminRouter;


### PR DESCRIPTION
## Problem

MetaMCP spawns one OS process per MCP server per session. With 16 configured servers, each new Claude Code session creates 16 processes. There is no per-server limit — only a global `maxTotalConnections` cap (default: 100).

In production, individual servers accumulate hundreds of duplicate processes:
- 627 copies of 1password-mcp
- 501 copies of onenote-mcp  
- 253 copies of reddit-mcp
- Total: ~2000 processes consuming 30+ GB RAM on a 32 GB machine

**Root cause:** The idle session replacement mechanism (`createIdleSessionAsync`) is fire-and-forget. Every time a session claims an idle connection, a new process is spawned as replacement — even if there are already dozens of active connections for that server. `SESSION_LIFETIME` cleanup only runs every 5 minutes and only kills sessions whose last-access timestamp is older than the lifetime, so actively-used sessions survive indefinitely.

## Solution

### 1. Per-server connection cap (`maxConnectionsPerServer`, default: 5)
- Prevents any single MCP server from accumulating more than N processes
- Enforced at three spawn points: `getSession()`, `createIdleSession()`, `createIdleSessionAsync()`
- When at cap, reuses the oldest active connection instead of spawning a new process

### 2. Touch session timestamps on access (idle-based cleanup)
- `SESSION_LIFETIME` now acts as an **idle timeout**, not a hard TTL
- Sessions that are actively used get their timestamp refreshed
- Only truly abandoned sessions get cleaned up

### 3. Cold-start warmup
- On first request after startup, ensures idle pool is populated

## Changes

- `mcp-server-pool.ts`: Add `maxConnectionsPerServer` field, `countConnectionsForServer()`, `canCreateConnectionForServer()`, `findOldestActiveConnectionForServer()` helpers. Cap checks in all three spawn paths. Per-server counts in `getPoolStatus()`.
- Touch `sessionTimestamps` on every `getSession()` access (not just creation)
- `McpServerPoolStatus` interface extended with `perServerCounts` and `maxConnectionsPerServer`

## Testing

- Verified type-checking passes (0 new errors)
- Dry-run tested against production MetaMCP instance with 16 configured servers
- External reaper script confirms per-server counts stay within cap after backend restart

Fixes #128 #162