### PR TITLE
feat: add admin role with RBAC and fix bootstrap signup block

### DIFF
--- a/apps/backend/drizzle/0014_shallow_black_panther.sql
+++ b/apps/backend/drizzle/0014_shallow_black_panther.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" text DEFAULT 'user' NOT NULL;

--- a/apps/backend/drizzle/meta/0014_snapshot.json
+++ b/apps/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1888 @@
+{
+  "id": "3ecd802e-2012-4957-99a2-0f9437588f00",
+  "prevId": "06d6c80e-47a8-4720-ba08-ec60b13f1098",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_is_active_idx": {
+          "name": "api_keys_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "api_keys_name_per_user_idx": {
+          "name": "api_keys_name_per_user_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config": {
+      "name": "config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.endpoints": {
+      "name": "endpoints",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_api_key_auth": {
+          "name": "enable_api_key_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_oauth": {
+          "name": "enable_oauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_max_rate": {
+          "name": "enable_max_rate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_client_max_rate": {
+          "name": "enable_client_max_rate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_rate": {
+          "name": "max_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_rate_seconds": {
+          "name": "max_rate_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate": {
+          "name": "client_max_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_seconds": {
+          "name": "client_max_rate_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_strategy": {
+          "name": "client_max_rate_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_strategy_key": {
+          "name": "client_max_rate_strategy_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_query_param_auth": {
+          "name": "use_query_param_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "endpoints_namespace_uuid_idx": {
+          "name": "endpoints_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "endpoints_user_id_idx": {
+          "name": "endpoints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "endpoints_namespace_uuid_namespaces_uuid_fk": {
+          "name": "endpoints_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "endpoints",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "endpoints_user_id_users_id_fk": {
+          "name": "endpoints_user_id_users_id_fk",
+          "tableFrom": "endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "endpoints_name_unique": {
+          "name": "endpoints_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "mcp_server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STDIO'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_status": {
+          "name": "error_status",
+          "type": "mcp_server_error_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NONE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_type_idx": {
+          "name": "mcp_servers_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_servers_user_id_idx": {
+          "name": "mcp_servers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_servers_error_status_idx": {
+          "name": "mcp_servers_error_status_idx",
+          "columns": [
+            {
+              "expression": "error_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_user_id_users_id_fk": {
+          "name": "mcp_servers_user_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_user_unique_idx": {
+          "name": "mcp_servers_name_user_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespace_server_mappings": {
+      "name": "namespace_server_mappings",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_server_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "namespace_server_mappings_namespace_uuid_idx": {
+          "name": "namespace_server_mappings_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_server_mappings_mcp_server_uuid_idx": {
+          "name": "namespace_server_mappings_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_server_mappings_status_idx": {
+          "name": "namespace_server_mappings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespace_server_mappings_namespace_uuid_namespaces_uuid_fk": {
+          "name": "namespace_server_mappings_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "namespace_server_mappings",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_server_mappings_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "namespace_server_mappings_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "namespace_server_mappings",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespace_server_mappings_unique_idx": {
+          "name": "namespace_server_mappings_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace_uuid",
+            "mcp_server_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespace_tool_mappings": {
+      "name": "namespace_tool_mappings",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_uuid": {
+          "name": "tool_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_server_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "override_name": {
+          "name": "override_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_title": {
+          "name": "override_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_annotations": {
+          "name": "override_annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "namespace_tool_mappings_namespace_uuid_idx": {
+          "name": "namespace_tool_mappings_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_tool_uuid_idx": {
+          "name": "namespace_tool_mappings_tool_uuid_idx",
+          "columns": [
+            {
+              "expression": "tool_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_mcp_server_uuid_idx": {
+          "name": "namespace_tool_mappings_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_status_idx": {
+          "name": "namespace_tool_mappings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespace_tool_mappings_namespace_uuid_namespaces_uuid_fk": {
+          "name": "namespace_tool_mappings_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_tool_mappings_tool_uuid_tools_uuid_fk": {
+          "name": "namespace_tool_mappings_tool_uuid_tools_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "tools",
+          "columnsFrom": [
+            "tool_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_tool_mappings_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "namespace_tool_mappings_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespace_tool_mappings_unique_idx": {
+          "name": "namespace_tool_mappings_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace_uuid",
+            "tool_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespaces": {
+      "name": "namespaces",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "namespaces_user_id_idx": {
+          "name": "namespaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespaces_user_id_users_id_fk": {
+          "name": "namespaces_user_id_users_id_fk",
+          "tableFrom": "namespaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespaces_name_user_unique_idx": {
+          "name": "namespaces_name_user_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"authorization_code\",\"refresh_token\"}'::text[]"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"code\"}'::text[]"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'admin'"
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_uri": {
+          "name": "tos_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_uri": {
+          "name": "policy_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_sessions": {
+      "name": "oauth_sessions",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_sessions_mcp_server_uuid_idx": {
+          "name": "oauth_sessions_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_sessions_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "oauth_sessions_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "oauth_sessions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_sessions_unique_per_server_idx": {
+          "name": "oauth_sessions_unique_per_server_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mcp_server_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_schema": {
+          "name": "tool_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_mcp_server_uuid_idx": {
+          "name": "tools_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "tools_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "tools",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tools_unique_tool_name_per_server_idx": {
+          "name": "tools_unique_tool_name_per_server_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mcp_server_uuid",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.mcp_server_error_status": {
+      "name": "mcp_server_error_status",
+      "schema": "public",
+      "values": [
+        "NONE",
+        "ERROR"
+      ]
+    },
+    "public.mcp_server_status": {
+      "name": "mcp_server_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.mcp_server_type": {
+      "name": "mcp_server_type",
+      "schema": "public",
+      "values": [
+        "STDIO",
+        "SSE",
+        "STREAMABLE_HTTP"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1766064780578,
       "tag": "0013_late_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1772687554897,
+      "tag": "0014_shallow_black_panther",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -118,6 +118,10 @@ export const auth = betterAuth({
         type: "boolean",
         defaultValue: false,
       },
+      role: {
+        type: "string",
+        defaultValue: "user",
+      },
     },
   },
   advanced: {

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -149,6 +149,7 @@ export const usersTable = pgTable("users", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").notNull().default(false),
   image: text("image"),
+  role: text("role").notNull().default("user"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/backend/src/lib/bootstrap.service.ts
+++ b/apps/backend/src/lib/bootstrap.service.ts
@@ -435,13 +435,14 @@ async function ensureUser(
     return { email, recreated };
   }
 
-  // Keep metadata consistent
+  // Keep metadata consistent and set bootstrap users as admin
   try {
     await db
       .update(usersTable)
       .set({
         name,
         emailVerified: true,
+        role: "admin",
         updatedAt: new Date(),
       })
       .where(eq(usersTable.id, user.id));
@@ -985,7 +986,50 @@ export async function initializeEnvironmentConfiguration(): Promise<void> {
 
   validateConfig(config);
 
-  // Registration controls (applied every run)
+  // One-time bootstrap guard
+  const skipBootstrap = await shouldSkipBootstrap(config);
+  if (skipBootstrap) {
+    console.log("✅ Environment-based configuration initialized (guarded)");
+    return;
+  }
+
+  // Temporarily allow signup so bootstrap user creation is not blocked
+  // by a DISABLE_SIGNUP=true value persisted from a previous run.
+  if (config.disableUiRegistration || config.disableSsoRegistration) {
+    try {
+      await upsertConfig(
+        ConfigKeyEnum.Enum.DISABLE_SIGNUP,
+        "false",
+        "Whether new user signup is disabled",
+      );
+      await upsertConfig(
+        ConfigKeyEnum.Enum.DISABLE_SSO_SIGNUP,
+        "false",
+        "Whether new user signup via SSO/OAuth is disabled",
+      );
+    } catch (err) {
+      console.warn("⚠️ Failed to temporarily allow signup for bootstrap:", err);
+    }
+  }
+
+  // Bootstrap all users (before registration controls to avoid sign-up being blocked)
+  let userMap: Map<string, string>;
+  try {
+    userMap = await bootstrapUsers(config);
+  } catch (err) {
+    console.warn("⚠️ Users bootstrap failed:", err);
+    userMap = new Map();
+  }
+
+  // Delete other users after bootstrapping configured users
+  try {
+    const bootstrappedEmails = Array.from(userMap.keys());
+    await maybeDeleteOtherUsers(config, bootstrappedEmails);
+  } catch (err) {
+    console.warn("⚠️ User cleanup step failed:", err);
+  }
+
+  // Registration controls (applied after user creation so DISABLE_SIGNUP doesn't block bootstrap sign-up)
   console.log("🔧 Setting registration controls...");
   try {
     await upsertConfig(
@@ -1010,30 +1054,6 @@ export async function initializeEnvironmentConfiguration(): Promise<void> {
   console.log(
     `✓ Registration controls set: UI=${!config.disableUiRegistration}, SSO=${!config.disableSsoRegistration}`,
   );
-
-  // One-time bootstrap guard
-  const skipBootstrap = await shouldSkipBootstrap(config);
-  if (skipBootstrap) {
-    console.log("✅ Environment-based configuration initialized (guarded)");
-    return;
-  }
-
-  // Bootstrap all users
-  let userMap: Map<string, string>;
-  try {
-    userMap = await bootstrapUsers(config);
-  } catch (err) {
-    console.warn("⚠️ Users bootstrap failed:", err);
-    userMap = new Map();
-  }
-
-  // Delete other users after bootstrapping configured users
-  try {
-    const bootstrappedEmails = Array.from(userMap.keys());
-    await maybeDeleteOtherUsers(config, bootstrappedEmails);
-  } catch (err) {
-    console.warn("⚠️ User cleanup step failed:", err);
-  }
 
   // Bootstrap API keys
   try {

--- a/apps/backend/src/trpc/endpoints.impl.ts
+++ b/apps/backend/src/trpc/endpoints.impl.ts
@@ -159,11 +159,13 @@ export const endpointsImplementations = {
 
   list: async (
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof ListEndpointsResponseSchema>> => {
     try {
-      // Get endpoints accessible to user (public + user's own) with namespace data
-      const endpoints =
-        await endpointsRepository.findAllAccessibleToUserWithNamespaces(userId);
+      // Admin can see all endpoints, regular users see public + own
+      const endpoints = userRole === "admin"
+        ? await endpointsRepository.findAllWithNamespaces()
+        : await endpointsRepository.findAllAccessibleToUserWithNamespaces(userId);
 
       return {
         success: true as const,
@@ -185,6 +187,7 @@ export const endpointsImplementations = {
       uuid: string;
     },
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof GetEndpointResponseSchema>> => {
     try {
       const endpoint = await endpointsRepository.findByUuidWithNamespace(
@@ -198,8 +201,8 @@ export const endpointsImplementations = {
         };
       }
 
-      // Check if user has access to this endpoint (own endpoint or public endpoint)
-      if (endpoint.user_id && endpoint.user_id !== userId) {
+      // Check if user has access to this endpoint (admin bypasses)
+      if (endpoint.user_id && endpoint.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message:
@@ -226,6 +229,7 @@ export const endpointsImplementations = {
       uuid: string;
     },
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof DeleteEndpointResponseSchema>> => {
     try {
       // First, check if the endpoint exists and user has permission to delete it
@@ -239,8 +243,8 @@ export const endpointsImplementations = {
         };
       }
 
-      // Check if user owns this endpoint (only owners can delete, protect public endpoints)
-      if (existingEndpoint.user_id && existingEndpoint.user_id !== userId) {
+      // Check if user owns this endpoint (admin bypasses)
+      if (existingEndpoint.user_id && existingEndpoint.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message: "Access denied: You can only delete endpoints you own",
@@ -275,6 +279,7 @@ export const endpointsImplementations = {
   update: async (
     input: z.infer<typeof UpdateEndpointRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof UpdateEndpointResponseSchema>> => {
     try {
       // First, check if the endpoint exists and user has permission to update it
@@ -288,8 +293,8 @@ export const endpointsImplementations = {
         };
       }
 
-      // Check if user owns this endpoint (only owners can update)
-      if (existingEndpoint.user_id && existingEndpoint.user_id !== userId) {
+      // Check if user owns this endpoint (admin bypasses)
+      if (existingEndpoint.user_id && existingEndpoint.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message: "Access denied: You can only update endpoints you own",

--- a/apps/backend/src/trpc/mcp-servers.impl.ts
+++ b/apps/backend/src/trpc/mcp-servers.impl.ts
@@ -82,11 +82,13 @@ export const mcpServersImplementations = {
 
   list: async (
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof ListMcpServersResponseSchema>> => {
     try {
-      // Find servers accessible to user (public + user's own)
-      const servers =
-        await mcpServersRepository.findAllAccessibleToUser(userId);
+      // Admin can see all servers, regular users see public + own
+      const servers = userRole === "admin"
+        ? await mcpServersRepository.findAll()
+        : await mcpServersRepository.findAllAccessibleToUser(userId);
 
       return {
         success: true as const,
@@ -204,12 +206,13 @@ export const mcpServersImplementations = {
       uuid: string;
     },
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof GetMcpServerResponseSchema>> => {
     try {
       const server = await mcpServersRepository.findByUuid(input.uuid);
 
-      // Check if user has access to this server (own server or public server)
-      if (server && server.user_id && server.user_id !== userId) {
+      // Check if user has access to this server (own server or public server, admin bypasses)
+      if (server && server.user_id && server.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message:
@@ -243,6 +246,7 @@ export const mcpServersImplementations = {
       uuid: string;
     },
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof DeleteMcpServerResponseSchema>> => {
     try {
       // Check if server exists and user has permission to delete it
@@ -255,8 +259,8 @@ export const mcpServersImplementations = {
         };
       }
 
-      // Only server owner can delete their own servers, only admin can delete public servers
-      if (server.user_id && server.user_id !== userId) {
+      // Only server owner can delete their own servers (admin bypasses)
+      if (server.user_id && server.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message: "Access denied: You can only delete servers you own",
@@ -338,6 +342,7 @@ export const mcpServersImplementations = {
   update: async (
     input: z.infer<typeof UpdateMcpServerRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof UpdateMcpServerResponseSchema>> => {
     try {
       // Check if server exists and user has permission to update it
@@ -350,8 +355,8 @@ export const mcpServersImplementations = {
         };
       }
 
-      // Only server owner can update their own servers, only admin can update public servers
-      if (server.user_id && server.user_id !== userId) {
+      // Only server owner can update their own servers (admin bypasses)
+      if (server.user_id && server.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message: "Access denied: You can only update servers you own",

--- a/apps/backend/src/trpc/namespaces.impl.ts
+++ b/apps/backend/src/trpc/namespaces.impl.ts
@@ -125,11 +125,13 @@ export const namespacesImplementations = {
 
   list: async (
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof ListNamespacesResponseSchema>> => {
     try {
-      // Find namespaces accessible to user (public + user's own)
-      const namespaces =
-        await namespacesRepository.findAllAccessibleToUser(userId);
+      // Admin can see all namespaces, regular users see public + own
+      const namespaces = userRole === "admin"
+        ? await namespacesRepository.findAll()
+        : await namespacesRepository.findAllAccessibleToUser(userId);
 
       return {
         success: true as const,
@@ -151,6 +153,7 @@ export const namespacesImplementations = {
       uuid: string;
     },
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof GetNamespaceResponseSchema>> => {
     try {
       const namespaceWithServers =
@@ -163,10 +166,11 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user has access to this namespace (own namespace or public namespace)
+      // Check if user has access to this namespace (admin bypasses)
       if (
         namespaceWithServers.user_id &&
-        namespaceWithServers.user_id !== userId
+        namespaceWithServers.user_id !== userId &&
+        userRole !== "admin"
       ) {
         return {
           success: false as const,
@@ -194,6 +198,7 @@ export const namespacesImplementations = {
   getTools: async (
     input: z.infer<typeof GetNamespaceToolsRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof GetNamespaceToolsResponseSchema>> => {
     try {
       // First, check if user has access to this namespace
@@ -209,8 +214,8 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user has access to this namespace (own namespace or public namespace)
-      if (namespace.user_id && namespace.user_id !== userId) {
+      // Check if user has access to this namespace (admin bypasses)
+      if (namespace.user_id && namespace.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           data: [],
@@ -243,6 +248,7 @@ export const namespacesImplementations = {
       uuid: string;
     },
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof DeleteNamespaceResponseSchema>> => {
     try {
       // First, check if the namespace exists and user has permission to delete it
@@ -257,8 +263,8 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user owns this namespace (only owners can delete, protect public namespaces)
-      if (existingNamespace.user_id && existingNamespace.user_id !== userId) {
+      // Check if user owns this namespace (admin bypasses)
+      if (existingNamespace.user_id && existingNamespace.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message: "Access denied: You can only delete namespaces you own",
@@ -313,6 +319,7 @@ export const namespacesImplementations = {
   update: async (
     input: z.infer<typeof UpdateNamespaceRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof UpdateNamespaceResponseSchema>> => {
     try {
       // First, check if the namespace exists and user has permission to update it
@@ -327,8 +334,8 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user owns this namespace (only owners can update)
-      if (existingNamespace.user_id && existingNamespace.user_id !== userId) {
+      // Check if user owns this namespace (admin bypasses)
+      if (existingNamespace.user_id && existingNamespace.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message: "Access denied: You can only update namespaces you own",
@@ -444,6 +451,7 @@ export const namespacesImplementations = {
   updateServerStatus: async (
     input: z.infer<typeof UpdateNamespaceServerStatusRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof UpdateNamespaceServerStatusResponseSchema>> => {
     try {
       // First, check if user has permission to update this namespace
@@ -458,8 +466,8 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user owns this namespace (only owners can update server status)
-      if (namespace.user_id && namespace.user_id !== userId) {
+      // Check if user owns this namespace (admin bypasses)
+      if (namespace.user_id && namespace.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message:
@@ -531,6 +539,7 @@ export const namespacesImplementations = {
   updateToolStatus: async (
     input: z.infer<typeof UpdateNamespaceToolStatusRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof UpdateNamespaceToolStatusResponseSchema>> => {
     try {
       // First, check if user has permission to update this namespace
@@ -545,8 +554,8 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user owns this namespace (only owners can update tool status)
-      if (namespace.user_id && namespace.user_id !== userId) {
+      // Check if user owns this namespace (admin bypasses)
+      if (namespace.user_id && namespace.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message:
@@ -587,6 +596,7 @@ export const namespacesImplementations = {
   updateToolOverrides: async (
     input: z.infer<typeof UpdateNamespaceToolOverridesRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof UpdateNamespaceToolOverridesResponseSchema>> => {
     try {
       // First, check if user has permission to update this namespace
@@ -601,8 +611,8 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user owns this namespace (only owners can update tool overrides)
-      if (namespace.user_id && namespace.user_id !== userId) {
+      // Check if user owns this namespace (admin bypasses)
+      if (namespace.user_id && namespace.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message:
@@ -651,6 +661,7 @@ export const namespacesImplementations = {
   refreshTools: async (
     input: z.infer<typeof RefreshNamespaceToolsRequestSchema>,
     userId: string,
+    userRole: string = "user",
   ): Promise<z.infer<typeof RefreshNamespaceToolsResponseSchema>> => {
     try {
       // First, check if user has permission to refresh tools for this namespace
@@ -665,8 +676,8 @@ export const namespacesImplementations = {
         };
       }
 
-      // Check if user owns this namespace (only owners can refresh tools)
-      if (namespace.user_id && namespace.user_id !== userId) {
+      // Check if user owns this namespace (admin bypasses)
+      if (namespace.user_id && namespace.user_id !== userId && userRole !== "admin") {
         return {
           success: false as const,
           message:

--- a/apps/frontend/app/[locale]/(sidebar)/layout.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/layout.tsx
@@ -125,9 +125,16 @@ function UserInfoFooter() {
         {user && (
           <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium">
-                {user.name || user.email}
-              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">
+                  {user.name || user.email}
+                </span>
+                {user.role === "admin" && (
+                  <span className="inline-flex items-center rounded-md bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary ring-1 ring-inset ring-primary/20">
+                    Admin
+                  </span>
+                )}
+              </div>
               <span className="text-xs text-muted-foreground">
                 {user.email}
               </span>

--- a/apps/frontend/lib/oauth-provider.ts
+++ b/apps/frontend/lib/oauth-provider.ts
@@ -20,8 +20,10 @@ class DbOAuthClientProvider implements OAuthClientProvider {
   constructor(mcpServerUuid: string, serverUrl: string) {
     this.mcpServerUuid = mcpServerUuid;
     this.serverUrl = serverUrl;
-    // Save the server URL to session storage for consistency
-    sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl);
+    // Save the server URL to session storage for consistency (browser only)
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl);
+    }
   }
 
   get redirectUrl() {

--- a/packages/trpc/src/routers/frontend/endpoints.ts
+++ b/packages/trpc/src/routers/frontend/endpoints.ts
@@ -22,22 +22,26 @@ export const createEndpointsRouter = (
     ) => Promise<z.infer<typeof CreateEndpointResponseSchema>>;
     list: (
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof ListEndpointsResponseSchema>>;
     get: (
       input: {
         uuid: string;
       },
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof GetEndpointResponseSchema>>;
     delete: (
       input: {
         uuid: string;
       },
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof DeleteEndpointResponseSchema>>;
     update: (
       input: z.infer<typeof UpdateEndpointRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof UpdateEndpointResponseSchema>>;
   },
 ) => {
@@ -46,7 +50,7 @@ export const createEndpointsRouter = (
     list: protectedProcedure
       .output(ListEndpointsResponseSchema)
       .query(async ({ ctx }) => {
-        return await implementations.list(ctx.user.id);
+        return await implementations.list(ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Get single endpoint by UUID
@@ -54,7 +58,7 @@ export const createEndpointsRouter = (
       .input(z.object({ uuid: z.string() }))
       .output(GetEndpointResponseSchema)
       .query(async ({ input, ctx }) => {
-        return await implementations.get(input, ctx.user.id);
+        return await implementations.get(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Create endpoint
@@ -70,7 +74,7 @@ export const createEndpointsRouter = (
       .input(z.object({ uuid: z.string() }))
       .output(DeleteEndpointResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.delete(input, ctx.user.id);
+        return await implementations.delete(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Update endpoint
@@ -78,7 +82,7 @@ export const createEndpointsRouter = (
       .input(UpdateEndpointRequestSchema)
       .output(UpdateEndpointResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.update(input, ctx.user.id);
+        return await implementations.update(input, ctx.user.id, ctx.user.role ?? "user");
       }),
   });
 };

--- a/packages/trpc/src/routers/frontend/mcp-servers.ts
+++ b/packages/trpc/src/routers/frontend/mcp-servers.ts
@@ -24,6 +24,7 @@ export const createMcpServersRouter = (
     ) => Promise<z.infer<typeof CreateMcpServerResponseSchema>>;
     list: (
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof ListMcpServersResponseSchema>>;
     bulkImport: (
       input: z.infer<typeof BulkImportMcpServersRequestSchema>,
@@ -34,16 +35,19 @@ export const createMcpServersRouter = (
         uuid: string;
       },
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof GetMcpServerResponseSchema>>;
     delete: (
       input: {
         uuid: string;
       },
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof DeleteMcpServerResponseSchema>>;
     update: (
       input: z.infer<typeof UpdateMcpServerRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof UpdateMcpServerResponseSchema>>;
   },
 ) => {
@@ -52,7 +56,7 @@ export const createMcpServersRouter = (
     list: protectedProcedure
       .output(ListMcpServersResponseSchema)
       .query(async ({ ctx }) => {
-        return await implementations.list(ctx.user.id);
+        return await implementations.list(ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Get single MCP server by UUID
@@ -60,7 +64,7 @@ export const createMcpServersRouter = (
       .input(z.object({ uuid: z.string() }))
       .output(GetMcpServerResponseSchema)
       .query(async ({ input, ctx }) => {
-        return await implementations.get(input, ctx.user.id);
+        return await implementations.get(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Create MCP server
@@ -84,7 +88,7 @@ export const createMcpServersRouter = (
       .input(z.object({ uuid: z.string() }))
       .output(DeleteMcpServerResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.delete(input, ctx.user.id);
+        return await implementations.delete(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Update MCP server
@@ -92,7 +96,7 @@ export const createMcpServersRouter = (
       .input(UpdateMcpServerRequestSchema)
       .output(UpdateMcpServerResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.update(input, ctx.user.id);
+        return await implementations.update(input, ctx.user.id, ctx.user.role ?? "user");
       }),
   });
 };

--- a/packages/trpc/src/routers/frontend/namespaces.ts
+++ b/packages/trpc/src/routers/frontend/namespaces.ts
@@ -32,42 +32,51 @@ export const createNamespacesRouter = (
     ) => Promise<z.infer<typeof CreateNamespaceResponseSchema>>;
     list: (
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof ListNamespacesResponseSchema>>;
     get: (
       input: {
         uuid: string;
       },
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof GetNamespaceResponseSchema>>;
     getTools: (
       input: z.infer<typeof GetNamespaceToolsRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof GetNamespaceToolsResponseSchema>>;
     delete: (
       input: {
         uuid: string;
       },
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof DeleteNamespaceResponseSchema>>;
     update: (
       input: z.infer<typeof UpdateNamespaceRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof UpdateNamespaceResponseSchema>>;
     updateServerStatus: (
       input: z.infer<typeof UpdateNamespaceServerStatusRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof UpdateNamespaceServerStatusResponseSchema>>;
     updateToolStatus: (
       input: z.infer<typeof UpdateNamespaceToolStatusRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof UpdateNamespaceToolStatusResponseSchema>>;
     updateToolOverrides: (
       input: z.infer<typeof UpdateNamespaceToolOverridesRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof UpdateNamespaceToolOverridesResponseSchema>>;
     refreshTools: (
       input: z.infer<typeof RefreshNamespaceToolsRequestSchema>,
       userId: string,
+      userRole: string,
     ) => Promise<z.infer<typeof RefreshNamespaceToolsResponseSchema>>;
   },
 ) => {
@@ -76,7 +85,7 @@ export const createNamespacesRouter = (
     list: protectedProcedure
       .output(ListNamespacesResponseSchema)
       .query(async ({ ctx }) => {
-        return await implementations.list(ctx.user.id);
+        return await implementations.list(ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Get single namespace by UUID
@@ -84,7 +93,7 @@ export const createNamespacesRouter = (
       .input(z.object({ uuid: z.string() }))
       .output(GetNamespaceResponseSchema)
       .query(async ({ input, ctx }) => {
-        return await implementations.get(input, ctx.user.id);
+        return await implementations.get(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Get tools for namespace from mapping table
@@ -92,7 +101,7 @@ export const createNamespacesRouter = (
       .input(GetNamespaceToolsRequestSchema)
       .output(GetNamespaceToolsResponseSchema)
       .query(async ({ input, ctx }) => {
-        return await implementations.getTools(input, ctx.user.id);
+        return await implementations.getTools(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Create namespace
@@ -108,7 +117,7 @@ export const createNamespacesRouter = (
       .input(z.object({ uuid: z.string() }))
       .output(DeleteNamespaceResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.delete(input, ctx.user.id);
+        return await implementations.delete(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Update namespace
@@ -116,7 +125,7 @@ export const createNamespacesRouter = (
       .input(UpdateNamespaceRequestSchema)
       .output(UpdateNamespaceResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.update(input, ctx.user.id);
+        return await implementations.update(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Update server status within namespace
@@ -124,7 +133,7 @@ export const createNamespacesRouter = (
       .input(UpdateNamespaceServerStatusRequestSchema)
       .output(UpdateNamespaceServerStatusResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.updateServerStatus(input, ctx.user.id);
+        return await implementations.updateServerStatus(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Update tool status within namespace
@@ -132,7 +141,7 @@ export const createNamespacesRouter = (
       .input(UpdateNamespaceToolStatusRequestSchema)
       .output(UpdateNamespaceToolStatusResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.updateToolStatus(input, ctx.user.id);
+        return await implementations.updateToolStatus(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Update tool overrides within namespace
@@ -140,7 +149,7 @@ export const createNamespacesRouter = (
       .input(UpdateNamespaceToolOverridesRequestSchema)
       .output(UpdateNamespaceToolOverridesResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.updateToolOverrides(input, ctx.user.id);
+        return await implementations.updateToolOverrides(input, ctx.user.id, ctx.user.role ?? "user");
       }),
 
     // Protected: Refresh tools from MetaMCP connection
@@ -148,7 +157,7 @@ export const createNamespacesRouter = (
       .input(RefreshNamespaceToolsRequestSchema)
       .output(RefreshNamespaceToolsResponseSchema)
       .mutation(async ({ input, ctx }) => {
-        return await implementations.refreshTools(input, ctx.user.id);
+        return await implementations.refreshTools(input, ctx.user.id, ctx.user.role ?? "user");
       }),
   });
 };


### PR DESCRIPTION
## Summary
- `users` 테이블에 `role` 컬럼 추가 (`user` / `admin`, 기본값 `user`) + DB 마이그레이션
- Bootstrap으로 생성된 사용자에 `admin` role 자동 부여
- Admin 사용자는 모든 namespace, MCP server, endpoint에 대한 소유권 체크 우회 (RBAC)
- tRPC 라우터에서 `userRole`을 backend implementation으로 전달
- Frontend 사이드바에 Admin 뱃지 표시
- `DISABLE_SIGNUP=true`가 DB에 남아있을 때 bootstrap 사용자 생성이 실패하는 버그 수정 (부트스트랩 전 일시적으로 signup 허용)

## Test plan
- [ ] `BOOTSTRAP_RECREATE_USER=true` + `BOOTSTRAP_DISABLE_REGISTRATION_UI=true` 상태에서 Pod 재시작 후 `✓ User ready:` 로그 확인
- [ ] Bootstrap 사용자가 `admin` role로 설정되는지 확인
- [ ] Admin 사용자가 다른 사용자의 namespace/MCP server/endpoint에 접근 가능한지 확인
- [ ] 일반 사용자가 여전히 본인 소유 + public 리소스만 접근 가능한지 확인
- [ ] 이후 일반 사용자의 sign-up이 차단되는지 확인
- [ ] Frontend에서 Admin 뱃지가 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)