### PR TITLE
Fix subprocess leaks from race conditions in STDIO transport lifecycle

### DIFF
--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -35,6 +35,11 @@ export class McpServerPool {
   // Track ongoing idle session creation to prevent duplicates
   private creatingIdleSessions: Set<string> = new Set();
 
+  // Generation counter per server UUID: incremented by invalidateIdleSession() so
+  // any in-flight createIdleSession / createIdleSessionAsync that resolves with a
+  // stale generation knows to discard its result instead of storing it.
+  private idleSessionGenerations: Record<string, number> = {};
+
   // Session cleanup timer
   private cleanupTimer: NodeJS.Timeout | null = null;
 
@@ -112,6 +117,19 @@ export class McpServerPool {
     const newClient = await this.createNewConnection(params, namespaceUuid);
     if (!newClient) {
       return undefined;
+    }
+
+    // Re-check after the async gap: a concurrent getSession() call for the same
+    // (sessionId, serverUuid) pair may have stored a connection while we were awaiting
+    // createNewConnection(). If so, discard ours to avoid leaking the spawned process.
+    if (this.activeSessions[sessionId]?.[serverUuid]) {
+      newClient.cleanup().catch((error) => {
+        logger.error(
+          `Error cleaning up duplicate connection for server ${params.uuid}:`,
+          error,
+        );
+      });
+      return this.activeSessions[sessionId][serverUuid];
     }
 
     this.activeSessions[sessionId][serverUuid] = newClient;
@@ -197,15 +215,46 @@ export class McpServerPool {
     params: ServerParameters,
     namespaceUuid?: string,
   ): Promise<void> {
-    // Don't create if we already have an idle session for this server
-    if (this.idleSessions[serverUuid]) {
+    // Don't create if we already have an idle session or are already creating one.
+    // Both checks are synchronous (before any await) so they act as a pre-await
+    // mutex, matching the pattern used by createIdleSessionAsync.
+    if (
+      this.idleSessions[serverUuid] ||
+      this.creatingIdleSessions.has(serverUuid)
+    ) {
       return;
     }
 
-    const newClient = await this.createNewConnection(params, namespaceUuid);
-    if (newClient) {
-      this.idleSessions[serverUuid] = newClient;
-      logger.info(`Created idle session for server ${serverUuid}`);
+    this.creatingIdleSessions.add(serverUuid);
+    const generation = this.idleSessionGenerations[serverUuid] ?? 0;
+
+    try {
+      const newClient = await this.createNewConnection(params, namespaceUuid);
+      if (newClient) {
+        const currentGeneration = this.idleSessionGenerations[serverUuid] ?? 0;
+        if (!this.idleSessions[serverUuid] && currentGeneration === generation) {
+          this.idleSessions[serverUuid] = newClient;
+          logger.info(`Created idle session for server ${serverUuid}`);
+        } else {
+          // Either a concurrent call already stored an idle session, or
+          // invalidateIdleSession() bumped the generation while we were awaiting,
+          // meaning our result is stale. Discard it.
+          newClient.cleanup().catch((error) => {
+            logger.error(
+              `Error cleaning up duplicate idle session for ${serverUuid}:`,
+              error,
+            );
+          });
+        }
+      }
+    } finally {
+      // Only release the guard if we're still the current creation for this
+      // server. If the generation was bumped while we were awaiting (e.g. by
+      // invalidateIdleSession), the guard now belongs to the newer creation
+      // and must not be removed here.
+      if ((this.idleSessionGenerations[serverUuid] ?? 0) === generation) {
+        this.creatingIdleSessions.delete(serverUuid);
+      }
     }
   }
 
@@ -227,11 +276,13 @@ export class McpServerPool {
 
     // Mark that we're creating an idle session for this server
     this.creatingIdleSessions.add(serverUuid);
+    const generation = this.idleSessionGenerations[serverUuid] ?? 0;
 
     // Create the session in the background (fire and forget)
     this.createNewConnection(params, namespaceUuid)
       .then((newClient) => {
-        if (newClient && !this.idleSessions[serverUuid]) {
+        const currentGeneration = this.idleSessionGenerations[serverUuid] ?? 0;
+        if (newClient && !this.idleSessions[serverUuid] && currentGeneration === generation) {
           this.idleSessions[serverUuid] = newClient;
           logger.info(
             `Created background idle session for server [${params.name}] ${serverUuid}`,
@@ -243,7 +294,8 @@ export class McpServerPool {
             );
           }
         } else if (newClient) {
-          // We already have an idle session, cleanup the extra one
+          // Either we already have an idle session, or invalidateIdleSession()
+          // bumped the generation while we were awaiting (stale result). Discard it.
           newClient.cleanup().catch((error) => {
             logger.error(
               `Error cleaning up extra idle session for ${serverUuid}:`,
@@ -259,8 +311,13 @@ export class McpServerPool {
         );
       })
       .finally(() => {
-        // Remove from creating set
-        this.creatingIdleSessions.delete(serverUuid);
+        // Only release the guard if we're still the current creation for this
+        // server. If the generation was bumped while we were awaiting (e.g. by
+        // invalidateIdleSession), the guard now belongs to the newer creation
+        // and must not be removed here.
+        if ((this.idleSessionGenerations[serverUuid] ?? 0) === generation) {
+          this.creatingIdleSessions.delete(serverUuid);
+        }
       });
   }
 
@@ -346,6 +403,18 @@ export class McpServerPool {
     this.sessionToServers = {};
     this.sessionTimestamps = {};
     this.serverParamsCache = {};
+
+    // Bump all known generations (never reset to {}) so any in-flight idle
+    // creation that started before cleanupAll() resolves with a stale value
+    // and discards itself. Cover both tracked entries and UUIDs that are only
+    // in creatingIdleSessions (which default to 0 and have no map entry yet).
+    for (const uuid of new Set([
+      ...Object.keys(this.idleSessionGenerations),
+      ...this.creatingIdleSessions,
+    ])) {
+      this.idleSessionGenerations[uuid] =
+        (this.idleSessionGenerations[uuid] ?? 0) + 1;
+    }
     this.creatingIdleSessions.clear();
 
     // Clear cleanup timer
@@ -468,7 +537,11 @@ export class McpServerPool {
       delete this.idleSessions[serverUuid];
     }
 
-    // Remove from creating set if it's in progress
+    // Bump the generation before clearing the in-progress guard so any
+    // in-flight createIdleSession / createIdleSessionAsync that resolves
+    // after this point will see a stale generation and discard its result.
+    this.idleSessionGenerations[serverUuid] =
+      (this.idleSessionGenerations[serverUuid] ?? 0) + 1;
     this.creatingIdleSessions.delete(serverUuid);
 
     // Create a new idle session with updated parameters
@@ -511,7 +584,13 @@ export class McpServerPool {
       delete this.idleSessions[serverUuid];
     }
 
-    // Remove from creating set if it's in progress
+    // Bump rather than delete the generation entry. Deleting would reset the
+    // effective value to 0 (via the ?? 0 default), which could spuriously match
+    // an in-flight creation that also captured 0 before this cleanup ran,
+    // allowing a stale subprocess to repopulate idleSessions after the server
+    // was removed.
+    this.idleSessionGenerations[serverUuid] =
+      (this.idleSessionGenerations[serverUuid] ?? 0) + 1;
     this.creatingIdleSessions.delete(serverUuid);
 
     // Remove from server params cache
@@ -586,6 +665,14 @@ export class McpServerPool {
    * Clean up all sessions for a specific server
    */
   private async cleanupServerSessions(serverUuid: string): Promise<void> {
+    // Bump generation and release the guard FIRST — before any await — so that
+    // an in-flight idle creation that resolves during the cleanup loop below
+    // (e.g. while we await an active-session cleanup) sees a stale generation
+    // and discards its result instead of storing it into the now-empty slot.
+    this.idleSessionGenerations[serverUuid] =
+      (this.idleSessionGenerations[serverUuid] ?? 0) + 1;
+    this.creatingIdleSessions.delete(serverUuid);
+
     // Clean up idle session
     const idleSession = this.idleSessions[serverUuid];
     if (idleSession) {
@@ -621,9 +708,6 @@ export class McpServerPool {
         this.sessionToServers[sessionId]?.delete(serverUuid);
       }
     }
-
-    // Remove from creating set
-    this.creatingIdleSessions.delete(serverUuid);
   }
 
   /**

--- a/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
+++ b/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
@@ -182,6 +182,9 @@ export class ProcessManagedStdioTransport implements Transport {
       });
 
       this._process.on("spawn", () => {
+        logger.info(
+          `[transport.start] spawned PID ${this._process?.pid} — command: ${this._serverParams.command}`,
+        );
         resolve();
       });
 
@@ -259,15 +262,46 @@ export class ProcessManagedStdioTransport implements Transport {
 
   async close(): Promise<void> {
     this._isCleanup = true;
-    this._abortController.abort();
 
-    // Kill the entire process group to ensure full cleanup
-    if (this._process?.pid) {
+    const pid = this._process?.pid ?? null;
+
+    if (pid) {
+      const proc = this._process!;
+
+      // Register the "close" listener BEFORE sending any signal so a fast-exiting
+      // child cannot emit "close" in between and cause the promise to time out.
+      const exitedPromise = new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => resolve(false), 5000);
+        proc.once("close", () => {
+          clearTimeout(timeout);
+          resolve(true);
+        });
+      });
+
+      this._abortController.abort();
+
       try {
-        process.kill(-this._process.pid, "SIGTERM");
+        process.kill(-pid, "SIGTERM");
+        logger.info(`[transport.close] SIGTERM sent to process group -${pid}`);
       } catch (error) {
-        // Process might already be terminated, ignore errors
-        logger.warn("Failed to kill process group:", error);
+        logger.warn(
+          `[transport.close] SIGTERM failed for process group -${pid}:`,
+          error,
+        );
+      }
+
+      // Wait up to 5 seconds for graceful shutdown, then escalate to SIGKILL
+      const exited = await exitedPromise;
+
+      if (!exited) {
+        logger.warn(
+          `[transport.close] Process ${pid} still alive after 5s — sending SIGKILL`,
+        );
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch {
+          // Process may have already exited between the timeout check and the kill
+        }
       }
     }
 


### PR DESCRIPTION
### Problem

Under concurrent load, MetaMCP can spawn STDIO subprocesses that are never tracked and therefore never terminated. These orphaned processes accumulate over time and cause steady RAM growth, eventually triggering OOM container restarts.

Two independent sources of leaks were identified:

1. ProcessManagedStdioTransport.close() — SIGTERM was fire-and-forget

close() sent SIGTERM to the process group and returned immediately without waiting for the child to exit. There was no fallback if the child ignored or delayed the signal, and no way to confirm the process was gone.

2. McpServerPool — three race conditions could orphan freshly spawned connections

getSession() TOCTOU: two concurrent calls for the same (sessionId, serverUuid) both passed the cache-hit check before either stored its result, then both awaited createNewConnection(). The second write won; the first connection was leaked.
createIdleSession() missing guard: the blocking createIdleSession() lacked the creatingIdleSessions pre-await mutex that createIdleSessionAsync() already used, so concurrent callers could race past the initial check and spawn duplicates.
Stale idle creation after invalidation: invalidateIdleSession() and the cleanup paths clear the slot and the guard but cannot cancel an already in-flight createNewConnection(). When the in-flight call resolved it could store a connection built with old parameters, silently defeating the refresh.

### Changes

`process-managed-transport.ts`

- Register the "close" listener before sending any signal so a fast-exiting child cannot emit "close" in the gap between the kill call and the listener attachment.
- Wait up to 5 seconds for the process to exit gracefully after SIGTERM, then escalate to SIGKILL if it is still alive.
- Move _abortController.abort() inside the pid-exists branch so it is only called when there is actually a live process.
- Log the spawned PID on start (command name only; args are omitted to avoid leaking credentials passed via argv) and log SIGTERM/SIGKILL outcomes for operational visibility.

`mcp-server-pool.ts`

- getSession(): add a post-await re-check that detects a duplicate connection created by a concurrent call and immediately calls cleanup() on it.
- createIdleSession(): apply the same creatingIdleSessions pre-await guard and post-await duplicate check already used by createIdleSessionAsync().
- Generation counter (idleSessionGenerations): each creation path captures the per-server counter before its await and discards its result if the counter has since changed. The finally guard-release is generation-gated so a stale creation cannot evict the guard owned by a newer one. All invalidation sites (invalidateIdleSession, cleanupIdleSession, cleanupServerSessions, cleanupAll) bump the counter before any await and before clearing the guard. Entries are always incremented rather than deleted, preventing the ?? 0 default from resetting the effective value to 0 and allowing a false match after server deletion.

### Testing
We've been running a backport of this patch to v2.4.22, together with #239, in production for three days. This has completely solved our process leak problem.