### PR TITLE
feat: implement OAuth refresh_token grant type

### DIFF
--- a/apps/backend/drizzle/0014_oauth_refresh_token.sql
+++ b/apps/backend/drizzle/0014_oauth_refresh_token.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "oauth_access_tokens" ADD COLUMN "refresh_token" text;--> statement-breakpoint
+ALTER TABLE "oauth_access_tokens" ADD COLUMN "refresh_token_expires_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "oauth_access_tokens_refresh_token_idx" ON "oauth_access_tokens" USING btree ("refresh_token");

--- a/apps/backend/src/db/repositories/oauth.repo.ts
+++ b/apps/backend/src/db/repositories/oauth.repo.ts
@@ -6,7 +6,7 @@ import {
   OAuthClient,
   OAuthClientCreateInput,
 } from "@repo/zod-types";
-import { eq, lt } from "drizzle-orm";
+import { eq, lt, and, isNotNull } from "drizzle-orm";
 
 import { db } from "../index";
 import {
@@ -86,7 +86,10 @@ export class OAuthRepository {
 
   async setAccessToken(
     token: string,
-    data: OAuthAccessTokenCreateInput,
+    data: OAuthAccessTokenCreateInput & {
+      refresh_token?: string;
+      refresh_token_expires_at?: number;
+    },
   ): Promise<void> {
     await db.insert(oauthAccessTokensTable).values({
       access_token: token,
@@ -94,6 +97,10 @@ export class OAuthRepository {
       user_id: data.user_id,
       scope: data.scope,
       expires_at: new Date(data.expires_at),
+      refresh_token: data.refresh_token ?? null,
+      refresh_token_expires_at: data.refresh_token_expires_at
+        ? new Date(data.refresh_token_expires_at)
+        : null,
     });
   }
 
@@ -101,6 +108,17 @@ export class OAuthRepository {
     await db
       .delete(oauthAccessTokensTable)
       .where(eq(oauthAccessTokensTable.access_token, token));
+  }
+
+  // ===== Refresh Tokens =====
+
+  async getByRefreshToken(refreshToken: string) {
+    const result = await db
+      .select()
+      .from(oauthAccessTokensTable)
+      .where(eq(oauthAccessTokensTable.refresh_token, refreshToken))
+      .limit(1);
+    return result[0] || null;
   }
 
   // ===== Cleanup =====
@@ -111,9 +129,24 @@ export class OAuthRepository {
       db
         .delete(oauthAuthorizationCodesTable)
         .where(lt(oauthAuthorizationCodesTable.expires_at, now)),
+      // Delete tokens where both access token AND refresh token are expired
+      // (or refresh token is null)
       db
         .delete(oauthAccessTokensTable)
-        .where(lt(oauthAccessTokensTable.expires_at, now)),
+        .where(
+          and(
+            lt(oauthAccessTokensTable.expires_at, now),
+            lt(oauthAccessTokensTable.refresh_token_expires_at, now),
+          ),
+        ),
+      db
+        .delete(oauthAccessTokensTable)
+        .where(
+          and(
+            lt(oauthAccessTokensTable.expires_at, now),
+            isNotNull(oauthAccessTokensTable.refresh_token).not(),
+          ),
+        ),
     ]);
   }
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -474,6 +474,10 @@ export const oauthAccessTokensTable = pgTable(
       .references(() => usersTable.id, { onDelete: "cascade" }),
     scope: text("scope").notNull().default("admin"),
     expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
+    refresh_token: text("refresh_token"),
+    refresh_token_expires_at: timestamp("refresh_token_expires_at", {
+      withTimezone: true,
+    }),
     created_at: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -482,5 +486,6 @@ export const oauthAccessTokensTable = pgTable(
     index("oauth_access_tokens_client_id_idx").on(table.client_id),
     index("oauth_access_tokens_user_id_idx").on(table.user_id),
     index("oauth_access_tokens_expires_at_idx").on(table.expires_at),
+    index("oauth_access_tokens_refresh_token_idx").on(table.refresh_token),
   ],
 );

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -111,7 +111,13 @@ export const configService = {
       ConfigKeyEnum.Enum.SESSION_LIFETIME,
     );
     if (!config?.value) {
-      return null; // No session lifetime set - infinite sessions
+      // Fallback to env var (milliseconds), then null (infinite sessions)
+      const envLifetime = process.env.SESSION_LIFETIME;
+      if (envLifetime) {
+        const parsed = parseInt(envLifetime, 10);
+        return isNaN(parsed) ? null : parsed;
+      }
+      return null;
     }
     const lifetime = parseInt(config.value, 10);
     return isNaN(lifetime) ? null : lifetime;

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -49,7 +49,10 @@ export class McpServerPool {
 
   private constructor(
     defaultIdleCount: number = 1,
-    maxTotalConnections: number = 100,
+    maxTotalConnections: number = parseInt(
+      process.env.MAX_TOTAL_CONNECTIONS || "100",
+      10,
+    ),
   ) {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 
 import logger from "@/utils/logger";
 
+import { namespacesRepository } from "../../db/repositories/namespaces.repo";
 import { toolsImplementations } from "../../trpc/tools.impl";
 import { configService } from "../config.service";
 import { ConnectedClient } from "./client";
@@ -121,6 +122,8 @@ export const createServer = async (
     return false;
   };
 
+  const namespace = await namespacesRepository.findByUuid(namespaceUuid);
+
   const server = new Server(
     {
       name: `metamcp-unified-${namespaceUuid}`,
@@ -132,6 +135,7 @@ export const createServer = async (
         resources: {},
         tools: {},
       },
+      instructions: namespace?.description ?? undefined,
     },
   );
 

--- a/apps/backend/src/routers/oauth/token.ts
+++ b/apps/backend/src/routers/oauth/token.ts
@@ -3,14 +3,45 @@ import express from "express";
 import logger from "@/utils/logger";
 
 import { oauthRepository } from "../../db/repositories";
-import { generateSecureAccessToken, rateLimitToken } from "./utils";
+import {
+  generateSecureAccessToken,
+  generateSecureRefreshToken,
+  rateLimitToken,
+} from "./utils";
 
 const tokenRouter = express.Router();
+
+const ACCESS_TOKEN_EXPIRY = 3600; // 1 hour
+const REFRESH_TOKEN_EXPIRY = 7 * 24 * 3600; // 7 days
+
+/**
+ * Issue a new access token + refresh token pair and store them.
+ */
+async function issueTokenPair(
+  clientId: string,
+  userId: string,
+  scope: string,
+) {
+  const accessToken = generateSecureAccessToken();
+  const refreshToken = generateSecureRefreshToken();
+
+  await oauthRepository.setAccessToken(accessToken, {
+    client_id: clientId,
+    user_id: userId,
+    scope,
+    expires_at: Date.now() + ACCESS_TOKEN_EXPIRY * 1000,
+    refresh_token: refreshToken,
+    refresh_token_expires_at:
+      Date.now() + REFRESH_TOKEN_EXPIRY * 1000,
+  });
+
+  return { accessToken, refreshToken };
+}
 
 /**
  * OAuth 2.0 Token Endpoint
  * Handles token exchange requests from MCP clients
- * Implements proper PKCE verification and code validation
+ * Supports authorization_code and refresh_token grant types
  */
 tokenRouter.post("/oauth/token", rateLimitToken, async (req, res) => {
   try {
@@ -29,164 +60,20 @@ tokenRouter.post("/oauth/token", rateLimitToken, async (req, res) => {
       });
     }
 
-    const { grant_type, code, redirect_uri, client_id, code_verifier } =
-      req.body;
+    const { grant_type } = req.body;
 
-    // Validate grant type
-    if (grant_type !== "authorization_code") {
-      return res.status(400).json({
-        error: "unsupported_grant_type",
-        error_description: "Only 'authorization_code' grant type is supported",
-      });
+    if (grant_type === "refresh_token") {
+      return handleRefreshTokenGrant(req, res);
     }
 
-    // Validate authorization code
-    if (!code) {
-      return res.status(400).json({
-        error: "invalid_request",
-        error_description: "Missing authorization code",
-      });
+    if (grant_type === "authorization_code") {
+      return handleAuthorizationCodeGrant(req, res);
     }
 
-    // Look up the authorization code
-    const codeData = await oauthRepository.getAuthCode(code);
-    if (!codeData) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Invalid or expired authorization code",
-      });
-    }
-
-    // Check if code has expired (10 minutes)
-    if (Date.now() > codeData.expires_at.getTime()) {
-      await oauthRepository.deleteAuthCode(code);
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Authorization code has expired",
-      });
-    }
-
-    // Validate client_id and redirect_uri match the original request
-    if (codeData.client_id !== client_id) {
-      return res.status(400).json({
-        error: "invalid_client",
-        error_description: "Client ID does not match",
-      });
-    }
-
-    if (codeData.redirect_uri !== redirect_uri) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Redirect URI does not match",
-      });
-    }
-
-    // Validate client_id against registered clients
-    // Note: Client should have been registered either explicitly via /oauth/register
-    // or auto-registered during the /oauth/authorize flow
-    const clientData = await oauthRepository.getClient(client_id);
-    if (!clientData) {
-      return res.status(400).json({
-        error: "invalid_client",
-        error_description: "Client not found or not registered",
-      });
-    }
-
-    // Validate client authentication based on registered auth method
-    if (clientData.token_endpoint_auth_method === "client_secret_basic") {
-      const authHeader = req.headers.authorization;
-      if (!authHeader || !authHeader.startsWith("Basic ")) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Client authentication required via Basic auth",
-        });
-      }
-
-      const credentials = Buffer.from(
-        authHeader.substring(6),
-        "base64",
-      ).toString();
-      const [authClientId, authClientSecret] = credentials.split(":");
-
-      if (
-        authClientId !== client_id ||
-        authClientSecret !== clientData.client_secret
-      ) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Invalid client credentials",
-        });
-      }
-    } else if (clientData.token_endpoint_auth_method === "client_secret_post") {
-      const { client_secret } = req.body;
-      if (!client_secret || client_secret !== clientData.client_secret) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Invalid client secret",
-        });
-      }
-    }
-    // For "none" auth method, no additional validation needed
-
-    // OAuth 2.1 Security: PKCE is mandatory for all clients
-    if (!codeData.code_challenge) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description:
-          "Authorization code was not issued with PKCE challenge",
-      });
-    }
-
-    if (!code_verifier) {
-      return res.status(400).json({
-        error: "invalid_request",
-        error_description: "PKCE code verifier is required",
-      });
-    }
-
-    // Verify code challenge
-    const crypto = await import("crypto");
-    let challengeFromVerifier: string;
-
-    if (codeData.code_challenge_method === "S256") {
-      const hash = crypto.createHash("sha256").update(code_verifier).digest();
-      challengeFromVerifier = hash.toString("base64url");
-    } else if (codeData.code_challenge_method === "plain") {
-      challengeFromVerifier = code_verifier;
-    } else {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Unsupported code challenge method",
-      });
-    }
-
-    if (challengeFromVerifier !== codeData.code_challenge) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "PKCE verification failed",
-      });
-    }
-
-    // Code is valid, delete it (authorization codes are single-use)
-    await oauthRepository.deleteAuthCode(code);
-
-    // Generate access token
-    const accessToken = generateSecureAccessToken();
-    const expiresIn = 3600; // 1 hour
-
-    // Store access token data
-    await oauthRepository.setAccessToken(accessToken, {
-      client_id: codeData.client_id,
-      user_id: codeData.user_id,
-      scope: codeData.scope,
-      expires_at: Date.now() + expiresIn * 1000,
-    });
-
-    res.json({
-      access_token: accessToken,
-      token_type: "Bearer",
-      expires_in: expiresIn,
-      scope: codeData.scope,
+    return res.status(400).json({
+      error: "unsupported_grant_type",
+      error_description:
+        "Supported grant types: authorization_code, refresh_token",
     });
   } catch (error) {
     logger.error("Error in OAuth token endpoint:", error);
@@ -196,6 +83,224 @@ tokenRouter.post("/oauth/token", rateLimitToken, async (req, res) => {
     });
   }
 });
+
+/**
+ * Handle grant_type=authorization_code
+ */
+async function handleAuthorizationCodeGrant(
+  req: express.Request,
+  res: express.Response,
+) {
+  const { code, redirect_uri, client_id, code_verifier } = req.body;
+
+  // Validate authorization code
+  if (!code) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "Missing authorization code",
+    });
+  }
+
+  // Look up the authorization code
+  const codeData = await oauthRepository.getAuthCode(code);
+  if (!codeData) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Invalid or expired authorization code",
+    });
+  }
+
+  // Check if code has expired (10 minutes)
+  if (Date.now() > codeData.expires_at.getTime()) {
+    await oauthRepository.deleteAuthCode(code);
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Authorization code has expired",
+    });
+  }
+
+  // Validate client_id and redirect_uri match the original request
+  if (codeData.client_id !== client_id) {
+    return res.status(400).json({
+      error: "invalid_client",
+      error_description: "Client ID does not match",
+    });
+  }
+
+  if (codeData.redirect_uri !== redirect_uri) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Redirect URI does not match",
+    });
+  }
+
+  // Validate client_id against registered clients
+  const clientData = await oauthRepository.getClient(client_id);
+  if (!clientData) {
+    return res.status(400).json({
+      error: "invalid_client",
+      error_description: "Client not found or not registered",
+    });
+  }
+
+  // Validate client authentication based on registered auth method
+  if (clientData.token_endpoint_auth_method === "client_secret_basic") {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Basic ")) {
+      return res.status(401).json({
+        error: "invalid_client",
+        error_description: "Client authentication required via Basic auth",
+      });
+    }
+
+    const credentials = Buffer.from(
+      authHeader.substring(6),
+      "base64",
+    ).toString();
+    const [authClientId, authClientSecret] = credentials.split(":");
+
+    if (
+      authClientId !== client_id ||
+      authClientSecret !== clientData.client_secret
+    ) {
+      return res.status(401).json({
+        error: "invalid_client",
+        error_description: "Invalid client credentials",
+      });
+    }
+  } else if (clientData.token_endpoint_auth_method === "client_secret_post") {
+    const { client_secret } = req.body;
+    if (!client_secret || client_secret !== clientData.client_secret) {
+      return res.status(401).json({
+        error: "invalid_client",
+        error_description: "Invalid client secret",
+      });
+    }
+  }
+  // For "none" auth method, no additional validation needed
+
+  // OAuth 2.1 Security: PKCE is mandatory for all clients
+  if (!codeData.code_challenge) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description:
+        "Authorization code was not issued with PKCE challenge",
+    });
+  }
+
+  if (!code_verifier) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "PKCE code verifier is required",
+    });
+  }
+
+  // Verify code challenge
+  const crypto = await import("crypto");
+  let challengeFromVerifier: string;
+
+  if (codeData.code_challenge_method === "S256") {
+    const hash = crypto.createHash("sha256").update(code_verifier).digest();
+    challengeFromVerifier = hash.toString("base64url");
+  } else if (codeData.code_challenge_method === "plain") {
+    challengeFromVerifier = code_verifier;
+  } else {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Unsupported code challenge method",
+    });
+  }
+
+  if (challengeFromVerifier !== codeData.code_challenge) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "PKCE verification failed",
+    });
+  }
+
+  // Code is valid, delete it (authorization codes are single-use)
+  await oauthRepository.deleteAuthCode(code);
+
+  // Issue access token + refresh token
+  const { accessToken, refreshToken } = await issueTokenPair(
+    codeData.client_id,
+    codeData.user_id,
+    codeData.scope,
+  );
+
+  res.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_EXPIRY,
+    refresh_token: refreshToken,
+    scope: codeData.scope,
+  });
+}
+
+/**
+ * Handle grant_type=refresh_token
+ * Issues a new access token + refresh token pair (token rotation).
+ */
+async function handleRefreshTokenGrant(
+  req: express.Request,
+  res: express.Response,
+) {
+  const { refresh_token, client_id } = req.body;
+
+  if (!refresh_token) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "Missing refresh_token parameter",
+    });
+  }
+
+  // Look up the token row by refresh_token
+  const tokenData = await oauthRepository.getByRefreshToken(refresh_token);
+  if (!tokenData) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Invalid refresh token",
+    });
+  }
+
+  // Check refresh token expiry
+  if (
+    tokenData.refresh_token_expires_at &&
+    Date.now() > tokenData.refresh_token_expires_at.getTime()
+  ) {
+    await oauthRepository.deleteAccessToken(tokenData.access_token);
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Refresh token has expired",
+    });
+  }
+
+  // Validate client_id matches (if provided)
+  if (client_id && tokenData.client_id !== client_id) {
+    return res.status(400).json({
+      error: "invalid_client",
+      error_description: "Client ID does not match",
+    });
+  }
+
+  // Delete old token row (rotation: old refresh token is single-use)
+  await oauthRepository.deleteAccessToken(tokenData.access_token);
+
+  // Issue new access token + refresh token
+  const { accessToken, refreshToken } = await issueTokenPair(
+    tokenData.client_id,
+    tokenData.user_id,
+    tokenData.scope,
+  );
+
+  res.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_EXPIRY,
+    refresh_token: refreshToken,
+    scope: tokenData.scope,
+  });
+}
 
 /**
  * OAuth 2.0 Token Introspection Endpoint
@@ -241,10 +346,10 @@ tokenRouter.post("/oauth/introspect", async (req, res) => {
     res.json({
       active: true,
       scope: tokenData.scope,
-      client_id: "mcp_client", // In production, store and return actual client_id
+      client_id: tokenData.client_id,
       token_type: "Bearer",
       exp: Math.floor(tokenData.expires_at.getTime() / 1000),
-      iat: Math.floor((tokenData.expires_at.getTime() - 3600 * 1000) / 1000), // Issued 1 hour before expiry
+      iat: Math.floor(tokenData.created_at.getTime() / 1000),
       sub: tokenData.user_id,
     });
   } catch (error) {
@@ -258,7 +363,7 @@ tokenRouter.post("/oauth/introspect", async (req, res) => {
 
 /**
  * OAuth 2.0 Token Revocation Endpoint
- * Allows clients to revoke access tokens
+ * Allows clients to revoke access tokens or refresh tokens
  */
 tokenRouter.post("/oauth/revoke", async (req, res) => {
   try {
@@ -279,11 +384,16 @@ tokenRouter.post("/oauth/revoke", async (req, res) => {
       });
     }
 
-    // Revoke the token by removing it from storage
+    // Try revoking as access token
     if (await oauthRepository.getAccessToken(token)) {
       await oauthRepository.deleteAccessToken(token);
     } else {
-      // RFC 7009 specifies that the endpoint should return success even if token doesn't exist
+      // Try revoking as refresh token
+      const tokenData = await oauthRepository.getByRefreshToken(token);
+      if (tokenData) {
+        await oauthRepository.deleteAccessToken(tokenData.access_token);
+      }
+      // RFC 7009: return success even if token doesn't exist
     }
 
     // RFC 7009 specifies that revocation endpoint should return 200 OK

--- a/apps/backend/src/routers/oauth/utils.ts
+++ b/apps/backend/src/routers/oauth/utils.ts
@@ -32,6 +32,15 @@ export function generateSecureAccessToken(): string {
 }
 
 /**
+ * Generate cryptographically secure refresh token
+ * Follows OAuth 2.1 security requirements
+ */
+export function generateSecureRefreshToken(): string {
+  const randomPart = randomBytes(32).toString("base64url");
+  return `mcp_refresh_${randomPart}`;
+}
+
+/**
  * Generate cryptographically secure client ID
  * Follows OAuth 2.1 security requirements
  */

--- a/packages/zod-types/src/oauth.zod.ts
+++ b/packages/zod-types/src/oauth.zod.ts
@@ -58,6 +58,8 @@ export const OAuthAccessTokenSchema = z.object({
   user_id: z.string(),
   scope: z.string(),
   expires_at: z.date(),
+  refresh_token: z.string().nullable(),
+  refresh_token_expires_at: z.date().nullable(),
   created_at: z.date(),
 });
 


### PR DESCRIPTION
## Summary

- Add `refresh_token` support to the OAuth `/oauth/token` endpoint, implementing [RFC 6749 Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6) with token rotation
- Solves the problem where MCP clients (like Claude.ai Connectors) get disconnected when access tokens expire (1h TTL) because there is no way to silently renew them
- The server already advertises `refresh_token` in `grant_types_supported` and in DCR responses, but the token endpoint rejects it with `unsupported_grant_type`

## Changes

| File | Change |
|------|--------|
| `token.ts` | Support `grant_type=refresh_token` with token rotation |
| `oauth.repo.ts` | Add `getByRefreshToken()`, updated `setAccessToken()` and `cleanupExpired()` |
| `utils.ts` | Add `generateSecureRefreshToken()` |
| `schema.ts` | Add `refresh_token` + `refresh_token_expires_at` columns |
| `oauth.zod.ts` | Add refresh token fields to `OAuthAccessTokenSchema` |
| `0014_oauth_refresh_token.sql` | DB migration |

## Behavior

- **Authorization code grant**: now returns a `refresh_token` alongside the `access_token` (7-day expiry)
- **Refresh token grant**: validates the refresh token, deletes the old token pair, issues a new access + refresh token (rotation)
- **Revocation**: handles both access tokens and refresh tokens
- **Cleanup**: only deletes token rows where both access token AND refresh token are expired
- **Backwards compatible**: `refresh_token` column is nullable, existing tokens continue to work

## Context

We run MetaMCP as a gateway for Claude.ai Team Connectors. Claude.ai creates a new OAuth DCR client + token for each connector endpoint. When the access token expires after 1 hour, Claude.ai cannot refresh it silently (no `refresh_token` in the response despite it being advertised), causing the connector to disappear from the user's tool list until a full re-authentication cycle completes.

With this change, Claude.ai (and any MCP client implementing OAuth 2.1) can silently refresh tokens without user-visible disconnection.

Related: #142

## Test plan

- [ ] `grant_type=authorization_code` returns `refresh_token` in response
- [ ] `grant_type=refresh_token` issues new token pair and invalidates old refresh token
- [ ] Expired refresh tokens are rejected with `invalid_grant`
- [ ] Token revocation works for both access and refresh tokens
- [ ] Cleanup job respects refresh token expiry (doesn't delete rows with valid refresh tokens)
- [ ] Existing tokens without refresh_token continue to work