### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,3 +499,8 @@ Some code inspired by:
 Not directly used the code by took ideas from
 - https://github.com/open-webui/openapi-servers
 - https://github.com/open-webui/mcpo
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/metatool-ai-metatool-app).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/metatool-ai-metatool-app)
