### PR TITLE
feat: make maxTotalConnections configurable via env var

### DIFF
--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -49,7 +49,10 @@ export class McpServerPool {
 
   private constructor(
     defaultIdleCount: number = 1,
-    maxTotalConnections: number = 100,
+    maxTotalConnections: number = parseInt(
+      process.env.MAX_TOTAL_CONNECTIONS || "100",
+      10,
+    ),
   ) {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;


### PR DESCRIPTION
## Problem

The `McpServerPool` constructor hardcodes `maxTotalConnections = 100`. For deployments with many MCP servers and namespaces, the connection pool saturates at 100 connections, causing new connections to be silently refused with a warning log:

```
Connection limit reached: 100/100. Refusing to create new connection.
```

There is no way to raise this limit without modifying the source code.

## Solution

Read the limit from the `MAX_TOTAL_CONNECTIONS` environment variable at startup, falling back to `100` if unset:

```typescript
maxTotalConnections: number = parseInt(
  process.env.MAX_TOTAL_CONNECTIONS || "100",
  10,
),
```

This is a one-line change with zero impact on existing deployments (default stays at 100).

## Testing

- Without `MAX_TOTAL_CONNECTIONS` set: pool behaves exactly as before (limit = 100).
- With `MAX_TOTAL_CONNECTIONS=500`: pool allows up to 500 total connections.