### PR TITLE
fix: read SESSION_LIFETIME from env var for session cleanup

### DIFF
--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -111,7 +111,13 @@ export const configService = {
       ConfigKeyEnum.Enum.SESSION_LIFETIME,
     );
     if (!config?.value) {
-      return null; // No session lifetime set - infinite sessions
+      // Fallback to env var (milliseconds), then null (infinite sessions)
+      const envLifetime = process.env.SESSION_LIFETIME;
+      if (envLifetime) {
+        const parsed = parseInt(envLifetime, 10);
+        return isNaN(parsed) ? null : parsed;
+      }
+      return null;
     }
     const lifetime = parseInt(config.value, 10);
     return isNaN(lifetime) ? null : lifetime;


### PR DESCRIPTION
## Problem

The session cleanup timer in `McpServerPool` and `MetaMcpServerPool` runs every 5 minutes but **skips cleanup entirely** when `configService.getSessionLifetime()` returns `null` — which is the default when no value is set in the DB config table via the Settings dashboard.

This means MCP sessions accumulate indefinitely, eventually saturating the connection pool. With 13 servers × 6 namespaces and OAuth token refreshes creating new sessions, the pool reaches `MAX_TOTAL_CONNECTIONS` and refuses all new connections:

```
Connection limit reached: 1000/1000. Refusing to create new connection.
Skipping connection for server metabase - connection limit reached
```

All connectors then show 0 tools.

## Fix

Add an env var fallback in `getSessionLifetime()`: when the DB config table has no `SESSION_LIFETIME` value, `process.env.SESSION_LIFETIME` is read instead. The DB config (via Settings dashboard) still takes priority.

This follows the same pattern as `MAX_TOTAL_CONNECTIONS` (PR #280).

## Usage

```yaml
environment:
  - SESSION_LIFETIME=3600000  # 1 hour in ms — sessions older than this are cleaned up
```

Without this env var (and without DB config), behavior is unchanged: infinite sessions, cleanup skipped.

## Changes

- `apps/backend/src/lib/config.service.ts`: env var fallback in `getSessionLifetime()`

## Related

- #280 — `MAX_TOTAL_CONNECTIONS` env var (same pattern)
- #276 — OAuth `refresh_token` grant (token refreshes create new sessions)