### PR TITLE
fix: re-initialize backend session on HTTP 404 Session not found

### DIFF
--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -471,6 +471,56 @@ export class McpServerPool {
   }
 
   /**
+   * Drop the pooled backend connection(s) for a given (sessionId, serverUuid).
+   *
+   * Used when the backend MCP server reports our Mcp-Session-Id is unknown
+   * (e.g. after the backend container restarts and loses its in-memory session
+   * registry). Both the active session and the paired idle session share the
+   * backend's session registry, so both are closed — if the backend forgot
+   * the active session, it has forgotten the idle one too. No replacement is
+   * created here; the next `getSession` call will establish a fresh
+   * connection (and therefore a fresh backend session) on demand.
+   */
+  async invalidateServerConnection(
+    sessionId: string,
+    serverUuid: string,
+  ): Promise<void> {
+    const activeForSession = this.activeSessions[sessionId];
+    const activeClient = activeForSession?.[serverUuid];
+    if (activeClient) {
+      try {
+        await activeClient.cleanup();
+      } catch (error) {
+        console.error(
+          `Error cleaning up invalidated active session ${sessionId}/${serverUuid}:`,
+          error,
+        );
+      }
+      delete activeForSession[serverUuid];
+      this.sessionToServers[sessionId]?.delete(serverUuid);
+    }
+
+    const idleClient = this.idleSessions[serverUuid];
+    if (idleClient) {
+      try {
+        await idleClient.cleanup();
+      } catch (error) {
+        console.error(
+          `Error cleaning up invalidated idle session for ${serverUuid}:`,
+          error,
+        );
+      }
+      delete this.idleSessions[serverUuid];
+    }
+
+    this.creatingIdleSessions.delete(serverUuid);
+
+    console.warn(
+      `Invalidated pooled backend connection for server ${serverUuid} (session ${sessionId})`,
+    );
+  }
+
+  /**
    * Handle server process crash
    */
   async handleServerCrash(

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -42,6 +42,7 @@ import {
   createToolOverridesListToolsMiddleware,
   mapOverrideNameToOriginal,
 } from "./metamcp-middleware/tool-overrides.functional";
+import { isBackendSessionLostError } from "./session-error";
 import { parseToolName } from "./tool-name-parser";
 import { sanitizeName } from "./utils";
 
@@ -404,23 +405,23 @@ export const createServer = async (
       throw new Error(`Server UUID not found for tool: ${name}`);
     }
 
-    try {
-      const abortController = new AbortController();
+    const abortController = new AbortController();
 
-      // Get configurable timeout values
-      const resetTimeoutOnProgress =
-        await configService.getMcpResetTimeoutOnProgress();
-      const timeout = await configService.getMcpTimeout();
-      const maxTotalTimeout = await configService.getMcpMaxTotalTimeout();
+    // Get configurable timeout values
+    const resetTimeoutOnProgress =
+      await configService.getMcpResetTimeoutOnProgress();
+    const timeout = await configService.getMcpTimeout();
+    const maxTotalTimeout = await configService.getMcpMaxTotalTimeout();
 
-      const mcpRequestOptions: RequestOptions = {
-        signal: abortController.signal,
-        resetTimeoutOnProgress,
-        timeout,
-        maxTotalTimeout,
-      };
-      // Use the correct schema for tool calls
-      const result = await clientForTool.client.request(
+    const mcpRequestOptions: RequestOptions = {
+      signal: abortController.signal,
+      resetTimeoutOnProgress,
+      timeout,
+      maxTotalTimeout,
+    };
+
+    const callOnce = (session: ConnectedClient) =>
+      session.client.request(
         {
           method: "tools/call",
           params: {
@@ -433,16 +434,62 @@ export const createServer = async (
         mcpRequestOptions,
       );
 
-      // Cast the result to CallToolResult type
-      return result as CallToolResult;
+    try {
+      return (await callOnce(clientForTool)) as CallToolResult;
     } catch (error) {
-      console.error(
-        `Error calling tool "${name}" through ${
-          clientForTool.client.getServerVersion()?.name || "unknown"
-        }:`,
-        error,
+      if (!isBackendSessionLostError(error)) {
+        console.error(
+          `Error calling tool "${name}" through ${
+            clientForTool.client.getServerVersion()?.name || "unknown"
+          }:`,
+          error,
+        );
+        throw error;
+      }
+
+      console.warn(
+        `Backend reported session lost for server ${serverUuid} on tool "${name}"; invalidating pool and retrying once.`,
       );
-      throw error;
+
+      await mcpServerPool.invalidateServerConnection(sessionId, serverUuid);
+      delete toolToClient[name];
+
+      const serverParamsMap = await getMcpServers(
+        namespaceUuid,
+        includeInactiveServers,
+      );
+      const params = serverParamsMap[serverUuid];
+      if (!params) {
+        throw new Error(
+          `Cannot re-initialize session: server ${serverUuid} no longer present in namespace ${namespaceUuid}`,
+        );
+      }
+
+      const freshSession = await mcpServerPool.getSession(
+        sessionId,
+        serverUuid,
+        params,
+        namespaceUuid,
+      );
+      if (!freshSession) {
+        throw new Error(
+          `Failed to re-initialize session for server ${serverUuid} after backend session loss`,
+        );
+      }
+
+      toolToClient[name] = freshSession;
+
+      try {
+        return (await callOnce(freshSession)) as CallToolResult;
+      } catch (retryError) {
+        console.error(
+          `Error calling tool "${name}" through ${
+            freshSession.client.getServerVersion()?.name || "unknown"
+          } after session re-initialize:`,
+          retryError,
+        );
+        throw retryError;
+      }
     }
   };
 

--- a/apps/backend/src/lib/metamcp/session-error.test.ts
+++ b/apps/backend/src/lib/metamcp/session-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { isBackendSessionLostError } from "./session-error";
+
+describe("isBackendSessionLostError", () => {
+  it("matches the HTTP 404 + JSON-RPC -32600 envelope the SDK produces", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("matches the HTTP 404 + JSON-RPC -32001 variant some servers return", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"error":{"code":-32001,"message":"Session not found"},"id":"","jsonrpc":"2.0"}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("does not match unrelated 404s", () => {
+    const error = new Error("Error POSTing to endpoint (HTTP 404): Not Found");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("does not match transport disconnects", () => {
+    const error = new Error("Not connected");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("returns false for non-Error inputs", () => {
+    expect(isBackendSessionLostError(undefined)).toBe(false);
+    expect(isBackendSessionLostError(null)).toBe(false);
+    expect(isBackendSessionLostError("Session not found")).toBe(false);
+  });
+});

--- a/apps/backend/src/lib/metamcp/session-error.ts
+++ b/apps/backend/src/lib/metamcp/session-error.ts
@@ -1,0 +1,32 @@
+/**
+ * Detect errors that indicate the backend MCP server's session registry no
+ * longer knows our Mcp-Session-Id. Per the MCP Streamable HTTP spec, the
+ * backend SHOULD respond with HTTP 404 when it cannot find the session; most
+ * SDKs also surface a JSON-RPC error body with code -32001 or -32600 and
+ * message "Session not found".
+ *
+ * The MCP TypeScript SDK's StreamableHTTPClientTransport wraps this as a
+ * generic Error whose message embeds the HTTP status and raw JSON-RPC body,
+ * so we match on substrings. Example:
+ *
+ *   Error POSTing to endpoint (HTTP 404):
+ *   {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}
+ *
+ * When this happens, the cached backend connection is dead: MetaMCP must drop
+ * it, send a new `initialize`, and replay the failed request. The MCP spec
+ * states the client MUST start a new session in response to HTTP 404, so this
+ * is the normative recovery path, not a workaround.
+ */
+export function isBackendSessionLostError(error: unknown): boolean {
+  if (!(error instanceof Error) || !error.message) {
+    return false;
+  }
+  const message = error.message;
+  const mentionsSessionNotFound = message.includes("Session not found");
+  const mentionsHttp404 = message.includes("HTTP 404");
+  const mentionsSessionErrorCode =
+    message.includes("-32001") || message.includes("-32600");
+  return (
+    mentionsSessionNotFound && (mentionsHttp404 || mentionsSessionErrorCode)
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #166. When a Streamable HTTP backend MCP server restarts (container replacement, process crash, scale-down → scale-up), its in-memory session registry is wiped. MetaMCP's pool still holds the old `Mcp-Session-Id`, so every subsequent `tools/call` POST is rejected with HTTP 404 + JSON-RPC `-32600`/`-32001` `Session not found`. The error was surfaced verbatim to the client and the stale cached connection was never invalidated, so the failure persisted forever until MetaMCP itself was bounced. In our production environment we accumulated ~8k failed tool calls over a few hours before a manual MetaMCP restart healed it.

The [MCP Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management) is explicit on the recovery path:

> When a client receives HTTP 404 in response to a request containing an Mcp-Session-Id, it MUST start a new session by sending a new InitializeRequest without a session ID attached.

This PR implements that for the MetaMCP → backend hop on the tool-call path.

## Changes

- **`lib/metamcp/session-error.ts`** (new) — `isBackendSessionLostError(err)` matches the SDK's wrapped error shape: `"HTTP 404"` + `"Session not found"` + `-32001`/`-32600`.
- **`lib/metamcp/session-error.test.ts`** (new) — 5 vitest cases covering the `-32600` envelope (MetaMCP log excerpt in #166-style repro), `-32001` envelope (what the issue reporter saw), unrelated 404s, transport disconnects, and non-`Error` inputs.
- **`lib/metamcp/mcp-server-pool.ts`** — new `invalidateServerConnection(sessionId, serverUuid)` method. Closes and drops both the active `ConnectedClient` for the given session *and* the paired idle client for the server (they share the backend's session registry — if the backend forgot one, it forgot both). No replacement is created eagerly; the next `getSession` call creates a fresh connection (and therefore a fresh `initialize` handshake) on demand.
- **`lib/metamcp/metamcp-proxy.ts`** `originalCallToolHandler` — catches `isBackendSessionLostError`, calls `invalidateServerConnection`, re-fetches server params via `getMcpServers`, re-acquires via `mcpServerPool.getSession` (which runs a fresh `initialize`), updates `toolToClient[name]`, and replays the tool call once. Unrelated errors re-thrown untouched.

The retry is bounded to one attempt. `initialize` is idempotent per spec, so the replayed tool call is safe.

## Scope

This PR only patches the tool-call path (`CallToolRequestSchema` handler in `metamcp-proxy.ts`), which is the hot path where the failure is loudest — every subsequent tool call fails forever until MetaMCP restarts. The same invalidation helper can be reused from `ListTools`, `GetPrompt`, `ListPrompts`, `ReadResource`, `ListResources`, `ListResourceTemplates` handlers and the OpenAPI `handlers.ts` call-tool site in a follow-up; kept this PR narrow to keep it reviewable.

## Reproduction

1. Stand up any Streamable HTTP MCP backend in a container.
2. Connect MetaMCP, make one tool call (primes backend session).
3. `docker restart` the backend container.
4. Make another tool call → observe `Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0",…,"error":{"code":-32600,"message":"Session not found"}}`.
5. Every subsequent tool call keeps failing with the same error.

Before this patch: loops forever. After: the first post-restart call still fails (the cache invalidation is reactive), but any subsequent call re-initializes transparently, and the healed path stays healthy.

## Log excerpt (from our prod, confirms the bug)

```
POST /mcp request for endpoint: autotask
Session ID: 8d75c378-1e48-4893-9a07-16e4aa9fa3fe
Looking up existing session: 8d75c378-1e48-4893-9a07-16e4aa9fa3fe
Found session 8d75c378-1e48-4893-9a07-16e4aa9fa3fe, handling request
Error calling tool "autotask__autotask_add_note" through autotask: Error: Error POSTing to endpoint (HTTP 404):
{"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}
```

Note the mismatch: MetaMCP's own (client-facing) session registry says "found, handling request" while the backend rejects MetaMCP's outbound session. The two session layers are independent; only the outbound one is dead.

## Test plan

- [x] `pnpm test` in `apps/backend` — 25/25 pass (20 preexisting + 5 new)
- [x] `pnpm build` in `apps/backend` — clean
- [x] `pnpm exec eslint` on changed files — no new warnings (preexisting prettier warnings in `metamcp-proxy.ts` unchanged)
- [ ] Manual: reviewer reproduces via the steps above

🤖 Generated with [Claude Code](https://claude.com/claude-code)