### PR TITLE
feat(auth): make better-auth session lifetimes env-var configurable

### DIFF
--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -109,8 +109,25 @@ export const auth = betterAuth({
     },
   },
   session: {
-    expiresIn: 60 * 60 * 24 * 7, // 7 days
-    updateAge: 60 * 60 * 24, // 1 day (how often to update the session)
+    // Session lifetimes are env-var configurable so deployers can tune
+    // how often users re-touch the gateway via SSO without rebuilding
+    // the image. Defaults match the previous hardcoded values exactly,
+    // so this is a strict superset — no behavior change for existing
+    // installs that don't set the env vars.
+    expiresIn: (() => {
+      const raw = process.env.BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS;
+      const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+      return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : 60 * 60 * 24 * 7; // 7 days (default)
+    })(),
+    updateAge: (() => {
+      const raw = process.env.BETTER_AUTH_SESSION_UPDATE_AGE_SECONDS;
+      const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+      return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : 60 * 60 * 24; // 1 day (default — how often the session expiry is bumped on access)
+    })(),
   },
   user: {
     additionalFields: {


### PR DESCRIPTION
## Why

The `session.expiresIn` and `session.updateAge` values in `apps/backend/src/auth.ts` are hardcoded today (7 days / 1 day). Deployers running self-hosted MetaMCP for long-lived AI client connections (where re-authenticating bounces users out of an active session) want to tune these without forking/rebuilding the image.

In particular: clients like Claude.ai connectors care about the underlying better-auth session because it gates `/oauth/authorize`. A short session means even a long-lived OAuth token can't refresh silently past the session boundary. For internal deployments where SSO is doing the access control work, a 30-day session is reasonable. For public/multi-tenant deployments, the existing 7 days stays the safe default.

## Change

Adds two env vars:

- `BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS` → overrides `expiresIn`
- `BETTER_AUTH_SESSION_UPDATE_AGE_SECONDS` → overrides `updateAge`

Both fall back to the existing hardcoded constants if unset or invalid. So this is a **strict superset** — no behavior change for installs that don't set the vars.

## Pattern

IIFE-wrapped reader with `Number.parseInt` + positive-integer guard. Same pattern that lands in PR #282 for `SESSION_LIFETIME` — the file already takes env-var input for similar config, this is just consistent with that.

## Why upstream

Files this against `main` rather than carrying it as a private fork patch indefinitely. If accepted, it's a one-line ENV pattern that benefits any deployer with non-standard session needs. If rejected, no harm done — we keep it on our fork.

## Test plan

- [x] Default behavior verified locally — env vars unset, session expires at the same `expiresIn` as before.
- [x] Override verified — `BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS=2592000` sets `auth.session.expiresIn` to 30 days.
- [x] Invalid input falls back — `BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS=foo` logs nothing (silent fallback, intentional — we don't want a deploy to crash on a typo) and uses the default.

Happy to add a unit test in `__tests__/` if helpful — just let me know which test framework you want it in.