### PR TITLE
Enable remote MCP OAuth sessions to survive Košík authorization

### DIFF
--- a/apps/backend/drizzle/0014_oauth_session_token_lifecycle.sql
+++ b/apps/backend/drizzle/0014_oauth_session_token_lifecycle.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "oauth_sessions" ALTER COLUMN "client_information" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "oauth_sessions" ALTER COLUMN "client_information" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "oauth_sessions" ADD COLUMN "tokens_obtained_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "oauth_sessions" ADD COLUMN "token_expires_at" timestamp with time zone;

--- a/apps/backend/drizzle/meta/0014_snapshot.json
+++ b/apps/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1892 @@
+{
+  "id": "55f6c8c2-9cf8-42a9-b50c-d7af63e7a8e6",
+  "prevId": "06d6c80e-47a8-4720-ba08-ec60b13f1098",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_is_active_idx": {
+          "name": "api_keys_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "api_keys_name_per_user_idx": {
+          "name": "api_keys_name_per_user_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config": {
+      "name": "config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.endpoints": {
+      "name": "endpoints",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_api_key_auth": {
+          "name": "enable_api_key_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_oauth": {
+          "name": "enable_oauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_max_rate": {
+          "name": "enable_max_rate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_client_max_rate": {
+          "name": "enable_client_max_rate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_rate": {
+          "name": "max_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_rate_seconds": {
+          "name": "max_rate_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate": {
+          "name": "client_max_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_seconds": {
+          "name": "client_max_rate_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_strategy": {
+          "name": "client_max_rate_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_strategy_key": {
+          "name": "client_max_rate_strategy_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_query_param_auth": {
+          "name": "use_query_param_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "endpoints_namespace_uuid_idx": {
+          "name": "endpoints_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "endpoints_user_id_idx": {
+          "name": "endpoints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "endpoints_namespace_uuid_namespaces_uuid_fk": {
+          "name": "endpoints_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "endpoints",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "endpoints_user_id_users_id_fk": {
+          "name": "endpoints_user_id_users_id_fk",
+          "tableFrom": "endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "endpoints_name_unique": {
+          "name": "endpoints_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "mcp_server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STDIO'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_status": {
+          "name": "error_status",
+          "type": "mcp_server_error_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NONE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_type_idx": {
+          "name": "mcp_servers_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_servers_user_id_idx": {
+          "name": "mcp_servers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_servers_error_status_idx": {
+          "name": "mcp_servers_error_status_idx",
+          "columns": [
+            {
+              "expression": "error_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_user_id_users_id_fk": {
+          "name": "mcp_servers_user_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_user_unique_idx": {
+          "name": "mcp_servers_name_user_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespace_server_mappings": {
+      "name": "namespace_server_mappings",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_server_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "namespace_server_mappings_namespace_uuid_idx": {
+          "name": "namespace_server_mappings_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_server_mappings_mcp_server_uuid_idx": {
+          "name": "namespace_server_mappings_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_server_mappings_status_idx": {
+          "name": "namespace_server_mappings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespace_server_mappings_namespace_uuid_namespaces_uuid_fk": {
+          "name": "namespace_server_mappings_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "namespace_server_mappings",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_server_mappings_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "namespace_server_mappings_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "namespace_server_mappings",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespace_server_mappings_unique_idx": {
+          "name": "namespace_server_mappings_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace_uuid",
+            "mcp_server_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespace_tool_mappings": {
+      "name": "namespace_tool_mappings",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_uuid": {
+          "name": "tool_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_server_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "override_name": {
+          "name": "override_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_title": {
+          "name": "override_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_annotations": {
+          "name": "override_annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "namespace_tool_mappings_namespace_uuid_idx": {
+          "name": "namespace_tool_mappings_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_tool_uuid_idx": {
+          "name": "namespace_tool_mappings_tool_uuid_idx",
+          "columns": [
+            {
+              "expression": "tool_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_mcp_server_uuid_idx": {
+          "name": "namespace_tool_mappings_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_status_idx": {
+          "name": "namespace_tool_mappings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespace_tool_mappings_namespace_uuid_namespaces_uuid_fk": {
+          "name": "namespace_tool_mappings_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_tool_mappings_tool_uuid_tools_uuid_fk": {
+          "name": "namespace_tool_mappings_tool_uuid_tools_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "tools",
+          "columnsFrom": [
+            "tool_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_tool_mappings_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "namespace_tool_mappings_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespace_tool_mappings_unique_idx": {
+          "name": "namespace_tool_mappings_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace_uuid",
+            "tool_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespaces": {
+      "name": "namespaces",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "namespaces_user_id_idx": {
+          "name": "namespaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespaces_user_id_users_id_fk": {
+          "name": "namespaces_user_id_users_id_fk",
+          "tableFrom": "namespaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespaces_name_user_unique_idx": {
+          "name": "namespaces_name_user_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"authorization_code\",\"refresh_token\"}'::text[]"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"code\"}'::text[]"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'admin'"
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_uri": {
+          "name": "tos_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_uri": {
+          "name": "policy_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_sessions": {
+      "name": "oauth_sessions",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tokens_obtained_at": {
+          "name": "tokens_obtained_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_sessions_mcp_server_uuid_idx": {
+          "name": "oauth_sessions_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_sessions_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "oauth_sessions_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "oauth_sessions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_sessions_unique_per_server_idx": {
+          "name": "oauth_sessions_unique_per_server_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mcp_server_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_schema": {
+          "name": "tool_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_mcp_server_uuid_idx": {
+          "name": "tools_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "tools_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "tools",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tools_unique_tool_name_per_server_idx": {
+          "name": "tools_unique_tool_name_per_server_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mcp_server_uuid",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.mcp_server_error_status": {
+      "name": "mcp_server_error_status",
+      "schema": "public",
+      "values": [
+        "NONE",
+        "ERROR"
+      ]
+    },
+    "public.mcp_server_status": {
+      "name": "mcp_server_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.mcp_server_type": {
+      "name": "mcp_server_type",
+      "schema": "public",
+      "values": [
+        "STDIO",
+        "SSE",
+        "STREAMABLE_HTTP"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1766064780578,
       "tag": "0013_late_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1778609914000,
+      "tag": "0014_oauth_session_token_lifecycle",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/oauth-sessions.repo.ts
+++ b/apps/backend/src/db/repositories/oauth-sessions.repo.ts
@@ -8,6 +8,19 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "../index";
 import { oauthSessionsTable } from "../schema";
 
+const hasOwn = <T extends object, K extends PropertyKey>(
+  input: T,
+  key: K,
+): input is T & Record<K, unknown> =>
+  Object.prototype.hasOwnProperty.call(input, key);
+
+const toDate = (value: string | Date | null | undefined) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  return value instanceof Date ? value : new Date(value);
+};
+
 export class OAuthSessionsRepository {
   async findByMcpServerUuid(
     mcpServerUuid: string,
@@ -26,11 +39,19 @@ export class OAuthSessionsRepository {
       .insert(oauthSessionsTable)
       .values({
         mcp_server_uuid: input.mcp_server_uuid,
-        ...(input.client_information && {
+        ...(hasOwn(input, "client_information") && {
           client_information: input.client_information,
         }),
-        ...(input.tokens && { tokens: input.tokens }),
-        ...(input.code_verifier && { code_verifier: input.code_verifier }),
+        ...(hasOwn(input, "tokens") && { tokens: input.tokens }),
+        ...(hasOwn(input, "code_verifier") && {
+          code_verifier: input.code_verifier,
+        }),
+        ...(hasOwn(input, "tokens_obtained_at") && {
+          tokens_obtained_at: toDate(input.tokens_obtained_at),
+        }),
+        ...(hasOwn(input, "token_expires_at") && {
+          token_expires_at: toDate(input.token_expires_at),
+        }),
       })
       .returning();
 
@@ -43,11 +64,19 @@ export class OAuthSessionsRepository {
     const [updatedSession] = await db
       .update(oauthSessionsTable)
       .set({
-        ...(input.client_information && {
+        ...(hasOwn(input, "client_information") && {
           client_information: input.client_information,
         }),
-        ...(input.tokens && { tokens: input.tokens }),
-        ...(input.code_verifier && { code_verifier: input.code_verifier }),
+        ...(hasOwn(input, "tokens") && { tokens: input.tokens }),
+        ...(hasOwn(input, "code_verifier") && {
+          code_verifier: input.code_verifier,
+        }),
+        ...(hasOwn(input, "tokens_obtained_at") && {
+          tokens_obtained_at: toDate(input.tokens_obtained_at),
+        }),
+        ...(hasOwn(input, "token_expires_at") && {
+          token_expires_at: toDate(input.token_expires_at),
+        }),
         updated_at: sql`NOW()`,
       })
       .where(eq(oauthSessionsTable.mcp_server_uuid, input.mcp_server_uuid))
@@ -84,6 +113,50 @@ export class OAuthSessionsRepository {
       .returning();
 
     return deletedSession;
+  }
+
+  async clearByMcpServerUuid(
+    mcpServerUuid: string,
+    scope: "all" | "client" | "tokens" | "verifier" = "all",
+  ): Promise<DatabaseOAuthSession | undefined> {
+    const values =
+      scope === "all"
+        ? {
+            client_information: null,
+            tokens: null,
+            code_verifier: null,
+            tokens_obtained_at: null,
+            token_expires_at: null,
+          }
+        : scope === "client"
+          ? {
+              client_information: null,
+              tokens: null,
+              code_verifier: null,
+              tokens_obtained_at: null,
+              token_expires_at: null,
+            }
+          : scope === "tokens"
+            ? {
+                tokens: null,
+                code_verifier: null,
+                tokens_obtained_at: null,
+                token_expires_at: null,
+              }
+            : {
+                code_verifier: null,
+              };
+
+    const [updatedSession] = await db
+      .update(oauthSessionsTable)
+      .set({
+        ...values,
+        updated_at: sql`NOW()`,
+      })
+      .where(eq(oauthSessionsTable.mcp_server_uuid, mcpServerUuid))
+      .returning();
+
+    return updatedSession;
   }
 }
 

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -90,12 +90,14 @@ export const oauthSessionsTable = pgTable(
     mcp_server_uuid: uuid("mcp_server_uuid")
       .notNull()
       .references(() => mcpServersTable.uuid, { onDelete: "cascade" }),
-    client_information: jsonb("client_information")
-      .$type<OAuthClientInformation>()
-      .notNull()
-      .default(sql`'{}'::jsonb`),
+    client_information:
+      jsonb("client_information").$type<OAuthClientInformation>(),
     tokens: jsonb("tokens").$type<OAuthTokens>(),
     code_verifier: text("code_verifier"),
+    tokens_obtained_at: timestamp("tokens_obtained_at", {
+      withTimezone: true,
+    }),
+    token_expires_at: timestamp("token_expires_at", { withTimezone: true }),
     created_at: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/backend/src/db/serializers/oauth-sessions.serializer.ts
+++ b/apps/backend/src/db/serializers/oauth-sessions.serializer.ts
@@ -9,6 +9,8 @@ type DatabaseOAuthSession = {
   client_information: OAuthClientInformation | null;
   tokens: OAuthTokens | null;
   code_verifier: string | null;
+  tokens_obtained_at: Date | null;
+  token_expires_at: Date | null;
   created_at: Date;
   updated_at: Date;
 };
@@ -19,6 +21,8 @@ type SerializedOAuthSession = {
   client_information: OAuthClientInformation | null;
   tokens: OAuthTokens | null;
   code_verifier: string | null;
+  tokens_obtained_at: string | null;
+  token_expires_at: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -33,6 +37,8 @@ export class OAuthSessionsSerializer {
       client_information: dbSession.client_information,
       tokens: dbSession.tokens,
       code_verifier: dbSession.code_verifier,
+      tokens_obtained_at: dbSession.tokens_obtained_at?.toISOString() ?? null,
+      token_expires_at: dbSession.token_expires_at?.toISOString() ?? null,
       created_at: dbSession.created_at.toISOString(),
       updated_at: dbSession.updated_at.toISOString(),
     };

--- a/apps/backend/src/lib/metamcp/client.ts
+++ b/apps/backend/src/lib/metamcp/client.ts
@@ -7,6 +7,7 @@ import { ServerParameters } from "@repo/zod-types";
 
 import logger from "@/utils/logger";
 
+import { clearOAuthTokensOnAuthFailure } from "../oauth/remote-oauth.service";
 import { ProcessManagedStdioTransport } from "../stdio-transport/process-managed-transport";
 import { metamcpLogStore } from "./log-store";
 import { serverErrorTracker } from "./server-error-tracker";
@@ -226,12 +227,14 @@ export const connectMetaMcpClient = async (
       }
 
       await client.connect(transport);
+      const connectedClient = client;
+      const connectedTransport = transport;
 
       return {
-        client,
+        client: connectedClient,
         cleanup: async () => {
-          await transport!.close();
-          await client!.close();
+          await connectedTransport.close();
+          await connectedClient.close();
         },
         onProcessCrash: (exitCode, signal) => {
           logger.warn(
@@ -245,6 +248,10 @@ export const connectMetaMcpClient = async (
         },
       };
     } catch (error) {
+      const clearedInvalidOAuthTokens = serverParams.oauth_tokens?.access_token
+        ? await clearOAuthTokensOnAuthFailure(serverParams.uuid, error)
+        : false;
+
       metamcpLogStore.addLog(
         "client",
         "error",
@@ -270,9 +277,18 @@ export const connectMetaMcpClient = async (
       if (client) {
         try {
           await client.close();
-        } catch (cleanupError) {
+        } catch (_cleanupError) {
           // Client may not be fully initialized, ignore
         }
+      }
+
+      if (clearedInvalidOAuthTokens) {
+        metamcpLogStore.addLog(
+          "client",
+          "error",
+          `OAuth credentials for ${serverParams.name} were rejected and cleared; reconnect after completing OAuth authorization again`,
+        );
+        return undefined;
       }
 
       count++;

--- a/apps/backend/src/lib/metamcp/fetch-metamcp.ts
+++ b/apps/backend/src/lib/metamcp/fetch-metamcp.ts
@@ -8,8 +8,8 @@ import { and, eq } from "drizzle-orm";
 import logger from "@/utils/logger";
 
 import { db } from "../../db/index";
-import { oauthSessionsRepository } from "../../db/repositories/index";
 import { mcpServersTable, namespaceServerMappingsTable } from "../../db/schema";
+import { getUsableOAuthTokens } from "../oauth/remote-oauth.service";
 import { getDefaultEnvironment } from "./utils";
 
 // Define IOType for stderr handling
@@ -66,21 +66,7 @@ export async function getMcpServers(
 
     const serverDict: Record<string, ServerParameters> = {};
     for (const server of servers) {
-      // Fetch OAuth tokens from OAuth sessions table
-      const oauthSession = await oauthSessionsRepository.findByMcpServerUuid(
-        server.uuid,
-      );
-      let oauthTokens = null;
-
-      if (oauthSession && oauthSession.tokens) {
-        oauthTokens = {
-          access_token: oauthSession.tokens.access_token,
-          token_type: oauthSession.tokens.token_type,
-          expires_in: oauthSession.tokens.expires_in,
-          scope: oauthSession.tokens.scope,
-          refresh_token: oauthSession.tokens.refresh_token,
-        };
-      }
+      const oauthTokens = await getUsableOAuthTokens(server.uuid, server.url);
 
       const params: ServerParameters = {
         uuid: server.uuid,

--- a/apps/backend/src/lib/metamcp/utils.ts
+++ b/apps/backend/src/lib/metamcp/utils.ts
@@ -2,7 +2,7 @@ import { DatabaseMcpServer, ServerParameters } from "@repo/zod-types";
 
 import logger from "@/utils/logger";
 
-import { oauthSessionsRepository } from "../../db/repositories/oauth-sessions.repo";
+import { getUsableOAuthTokens } from "../oauth/remote-oauth.service";
 
 /**
  * Environment variables to inherit by default, if an environment is not explicitly given.
@@ -86,21 +86,7 @@ export async function convertDbServerToParams(
   server: DatabaseMcpServer,
 ): Promise<ServerParameters | null> {
   try {
-    // Fetch OAuth tokens from OAuth sessions table
-    const oauthSession = await oauthSessionsRepository.findByMcpServerUuid(
-      server.uuid,
-    );
-    let oauthTokens = null;
-
-    if (oauthSession && oauthSession.tokens) {
-      oauthTokens = {
-        access_token: oauthSession.tokens.access_token,
-        token_type: oauthSession.tokens.token_type,
-        expires_in: oauthSession.tokens.expires_in,
-        scope: oauthSession.tokens.scope,
-        refresh_token: oauthSession.tokens.refresh_token,
-      };
-    }
+    const oauthTokens = await getUsableOAuthTokens(server.uuid, server.url);
 
     const params: ServerParameters = {
       uuid: server.uuid,
@@ -155,10 +141,10 @@ export async function convertDbServerToParams(
  * @param envObject Environment object that may contain placeholder values
  * @returns Environment object with resolved values
  */
-export function resolveEnvVariables(
-  envObject: Record<string, any>,
-): Record<string, any> {
-  const resolved: Record<string, any> = {};
+export function resolveEnvVariables<
+  T extends Record<string, string | undefined>,
+>(envObject: T): T {
+  const resolved: Record<string, string | undefined> = {};
 
   for (const [key, value] of Object.entries(envObject)) {
     if (
@@ -183,5 +169,5 @@ export function resolveEnvVariables(
     }
   }
 
-  return resolved;
+  return resolved as T;
 }

--- a/apps/backend/src/lib/oauth/remote-oauth.service.test.ts
+++ b/apps/backend/src/lib/oauth/remote-oauth.service.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const oauthSessionsRepository = {
+  findByMcpServerUuid: vi.fn(),
+  upsert: vi.fn(),
+  clearByMcpServerUuid: vi.fn(),
+};
+
+const discoverOAuthProtectedResourceMetadata = vi.fn();
+const discoverOAuthMetadata = vi.fn();
+const selectResourceURL = vi.fn();
+const refreshAuthorization = vi.fn();
+
+vi.mock("../../db/repositories/oauth-sessions.repo", () => ({
+  oauthSessionsRepository,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  discoverOAuthProtectedResourceMetadata,
+  discoverOAuthMetadata,
+  selectResourceURL,
+  refreshAuthorization,
+}));
+
+const { clearOAuthTokensOnAuthFailure, getUsableOAuthTokens } = await import(
+  "./remote-oauth.service"
+);
+
+describe("remote OAuth service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes expiring tokens with protected resource metadata", async () => {
+    const updatedAt = new Date("2026-05-12T18:00:00.000Z");
+    oauthSessionsRepository.findByMcpServerUuid.mockResolvedValue({
+      client_information: { client_id: "client-1" },
+      tokens: {
+        access_token: "old-token",
+        token_type: "Bearer",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+      },
+      token_expires_at: new Date(Date.now() - 1000),
+      tokens_obtained_at: updatedAt,
+      updated_at: updatedAt,
+    });
+    discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+      resource: "https://mcp.kosik.cz/mcp",
+      authorization_servers: ["https://mcp.kosik.cz/mcp"],
+    });
+    selectResourceURL.mockResolvedValue(new URL("https://mcp.kosik.cz/mcp"));
+    discoverOAuthMetadata.mockResolvedValue({
+      issuer: "https://mcp.kosik.cz/mcp",
+      token_endpoint: "https://mcp.kosik.cz/mcp/token",
+      authorization_endpoint: "https://mcp.kosik.cz/mcp/authorize",
+      response_types_supported: ["code"],
+    });
+    refreshAuthorization.mockResolvedValue({
+      access_token: "new-token",
+      token_type: "Bearer",
+      refresh_token: "refresh-token",
+      expires_in: 3600,
+    });
+
+    const tokens = await getUsableOAuthTokens(
+      "server-1",
+      "https://mcp.kosik.cz/mcp/",
+    );
+
+    expect(tokens?.access_token).toBe("new-token");
+    expect(refreshAuthorization).toHaveBeenCalledWith(
+      "https://mcp.kosik.cz/mcp",
+      expect.objectContaining({
+        clientInformation: { client_id: "client-1" },
+        refreshToken: "refresh-token",
+        resource: new URL("https://mcp.kosik.cz/mcp"),
+      }),
+    );
+    expect(oauthSessionsRepository.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcp_server_uuid: "server-1",
+        code_verifier: null,
+        tokens: expect.objectContaining({ access_token: "new-token" }),
+        token_expires_at: expect.any(Date),
+        tokens_obtained_at: expect.any(Date),
+      }),
+    );
+  });
+
+  it("clears invalid refresh credentials", async () => {
+    oauthSessionsRepository.findByMcpServerUuid.mockResolvedValue({
+      client_information: { client_id: "client-1" },
+      tokens: {
+        access_token: "old-token",
+        token_type: "Bearer",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+      },
+      token_expires_at: new Date(Date.now() - 1000),
+      tokens_obtained_at: new Date(),
+      updated_at: new Date(),
+    });
+    discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+      resource: "https://mcp.kosik.cz/mcp",
+    });
+    selectResourceURL.mockResolvedValue(new URL("https://mcp.kosik.cz/mcp"));
+    discoverOAuthMetadata.mockResolvedValue(undefined);
+    refreshAuthorization.mockRejectedValue(new Error("invalid_grant"));
+
+    const tokens = await getUsableOAuthTokens(
+      "server-1",
+      "https://mcp.kosik.cz/mcp/",
+    );
+
+    expect(tokens).toBeNull();
+    expect(oauthSessionsRepository.clearByMcpServerUuid).toHaveBeenCalledWith(
+      "server-1",
+      "tokens",
+    );
+  });
+
+  it("does not return an expired token when refresh fails without invalidating credentials", async () => {
+    oauthSessionsRepository.findByMcpServerUuid.mockResolvedValue({
+      client_information: { client_id: "client-1" },
+      tokens: {
+        access_token: "expired-token",
+        token_type: "Bearer",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+      },
+      token_expires_at: new Date(Date.now() - 1000),
+      tokens_obtained_at: new Date(Date.now() - 3_600_000),
+      updated_at: new Date(Date.now() - 3_600_000),
+    });
+    discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+      resource: "https://mcp.kosik.cz/mcp",
+    });
+    selectResourceURL.mockResolvedValue(new URL("https://mcp.kosik.cz/mcp"));
+    discoverOAuthMetadata.mockResolvedValue(undefined);
+    refreshAuthorization.mockRejectedValue(new Error("network timeout"));
+
+    const tokens = await getUsableOAuthTokens(
+      "server-1",
+      "https://mcp.kosik.cz/mcp/",
+    );
+
+    expect(tokens).toBeNull();
+    expect(oauthSessionsRepository.clearByMcpServerUuid).not.toHaveBeenCalled();
+  });
+
+  it("does not return an expired token that cannot be refreshed", async () => {
+    oauthSessionsRepository.findByMcpServerUuid.mockResolvedValue({
+      client_information: { client_id: "client-1" },
+      tokens: {
+        access_token: "expired-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      },
+      token_expires_at: new Date(Date.now() - 1000),
+      tokens_obtained_at: new Date(Date.now() - 3_600_000),
+      updated_at: new Date(Date.now() - 3_600_000),
+    });
+
+    const tokens = await getUsableOAuthTokens(
+      "server-1",
+      "https://mcp.kosik.cz/mcp/",
+    );
+
+    expect(tokens).toBeNull();
+    expect(refreshAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("reports whether upstream auth failure cleared stored tokens", async () => {
+    await expect(
+      clearOAuthTokensOnAuthFailure("server-1", new Error("invalid_token")),
+    ).resolves.toBe(true);
+    expect(oauthSessionsRepository.clearByMcpServerUuid).toHaveBeenCalledWith(
+      "server-1",
+      "tokens",
+    );
+
+    vi.clearAllMocks();
+
+    await expect(
+      clearOAuthTokensOnAuthFailure("server-1", new Error("network timeout")),
+    ).resolves.toBe(false);
+    expect(oauthSessionsRepository.clearByMcpServerUuid).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/lib/oauth/remote-oauth.service.ts
+++ b/apps/backend/src/lib/oauth/remote-oauth.service.ts
@@ -1,0 +1,222 @@
+import {
+  discoverOAuthMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  refreshAuthorization,
+  selectResourceURL,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import { OAuthClientMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { OAuthTokens } from "@repo/zod-types";
+
+import { oauthSessionsRepository } from "../../db/repositories/oauth-sessions.repo";
+import logger from "../../utils/logger";
+
+const REFRESH_SKEW_MS = 60_000;
+
+const refreshClientMetadata: OAuthClientMetadata = {
+  redirect_uris: ["http://localhost/oauth-refresh-placeholder"],
+  token_endpoint_auth_method: "none",
+  grant_types: ["authorization_code", "refresh_token"],
+  response_types: ["code"],
+  client_name: "MetaMCP",
+};
+
+const getErrorCode = (error: unknown) => {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const maybeError = error as { errorCode?: unknown; name?: unknown };
+  if (typeof maybeError.errorCode === "string") {
+    return maybeError.errorCode;
+  }
+  if (typeof maybeError.name === "string") {
+    return maybeError.name;
+  }
+  return undefined;
+};
+
+const isInvalidOAuthCredentialError = (error: unknown) => {
+  const code = getErrorCode(error);
+  if (
+    code === "invalid_grant" ||
+    code === "invalid_client" ||
+    code === "invalid_token" ||
+    code === "InvalidGrantError" ||
+    code === "InvalidClientError" ||
+    code === "InvalidTokenError"
+  ) {
+    return true;
+  }
+
+  return error instanceof Error
+    ? /invalid_(grant|client|token)|unauthorized/i.test(error.message)
+    : false;
+};
+
+const computeTokenExpiry = (tokens: OAuthTokens, obtainedAt: Date) =>
+  tokens.expires_in
+    ? new Date(obtainedAt.getTime() + tokens.expires_in * 1000)
+    : null;
+
+const getEffectiveTokenExpiry = (
+  tokens: OAuthTokens,
+  tokenExpiresAt: Date | null,
+  tokensObtainedAt: Date | null,
+  updatedAt: Date,
+) =>
+  tokenExpiresAt ??
+  (tokens.expires_in
+    ? computeTokenExpiry(tokens, tokensObtainedAt ?? updatedAt)
+    : null);
+
+const needsRefresh = (
+  tokens: OAuthTokens,
+  tokenExpiresAt: Date | null,
+  tokensObtainedAt: Date | null,
+  updatedAt: Date,
+) => {
+  const expiresAt = getEffectiveTokenExpiry(
+    tokens,
+    tokenExpiresAt,
+    tokensObtainedAt,
+    updatedAt,
+  );
+
+  if (!expiresAt) {
+    return false;
+  }
+
+  return expiresAt.getTime() <= Date.now() + REFRESH_SKEW_MS;
+};
+
+export async function clearOAuthCredentialsForServer(
+  mcpServerUuid: string,
+  scope: "all" | "client" | "tokens" | "verifier" = "tokens",
+) {
+  await oauthSessionsRepository.clearByMcpServerUuid(mcpServerUuid, scope);
+}
+
+export async function getUsableOAuthTokens(
+  mcpServerUuid: string,
+  serverUrl?: string | null,
+): Promise<OAuthTokens | null> {
+  const session =
+    await oauthSessionsRepository.findByMcpServerUuid(mcpServerUuid);
+
+  if (!session?.tokens) {
+    return null;
+  }
+
+  if (!serverUrl || !session.client_information) {
+    return needsRefresh(
+      session.tokens,
+      session.token_expires_at,
+      session.tokens_obtained_at,
+      session.updated_at,
+    )
+      ? null
+      : session.tokens;
+  }
+
+  if (
+    !needsRefresh(
+      session.tokens,
+      session.token_expires_at,
+      session.tokens_obtained_at,
+      session.updated_at,
+    )
+  ) {
+    return session.tokens;
+  }
+
+  if (!session.tokens.refresh_token) {
+    logger.warn(
+      `OAuth token for MCP server ${mcpServerUuid} is expired and cannot be refreshed; reauthorization is required`,
+    );
+    return null;
+  }
+
+  try {
+    let resourceMetadata;
+    let authorizationServerUrl: string | URL = serverUrl;
+
+    try {
+      resourceMetadata =
+        await discoverOAuthProtectedResourceMetadata(serverUrl);
+      if (resourceMetadata.authorization_servers?.[0]) {
+        authorizationServerUrl = resourceMetadata.authorization_servers[0];
+      }
+    } catch {
+      resourceMetadata = undefined;
+    }
+
+    const resource = await selectResourceURL(
+      serverUrl,
+      {
+        redirectUrl: refreshClientMetadata.redirect_uris[0],
+        clientMetadata: refreshClientMetadata,
+        clientInformation: () => session.client_information ?? undefined,
+        tokens: () => session.tokens ?? undefined,
+        saveTokens: () => undefined,
+        redirectToAuthorization: () => undefined,
+        saveCodeVerifier: () => undefined,
+        codeVerifier: () => "",
+      },
+      resourceMetadata,
+    );
+
+    const metadata = await discoverOAuthMetadata(serverUrl, {
+      authorizationServerUrl,
+    });
+
+    const refreshedTokens = await refreshAuthorization(authorizationServerUrl, {
+      metadata,
+      clientInformation: session.client_information,
+      refreshToken: session.tokens.refresh_token,
+      resource,
+    });
+
+    const obtainedAt = new Date();
+    await oauthSessionsRepository.upsert({
+      mcp_server_uuid: mcpServerUuid,
+      tokens: refreshedTokens,
+      tokens_obtained_at: obtainedAt,
+      token_expires_at: computeTokenExpiry(refreshedTokens, obtainedAt),
+      code_verifier: null,
+    });
+
+    logger.info(
+      `Refreshed OAuth tokens for MCP server ${mcpServerUuid} without exposing token values`,
+    );
+
+    return refreshedTokens;
+  } catch (error) {
+    if (isInvalidOAuthCredentialError(error)) {
+      await clearOAuthCredentialsForServer(mcpServerUuid, "tokens");
+      logger.warn(
+        `Cleared invalid OAuth tokens for MCP server ${mcpServerUuid}; reauthorization is required`,
+      );
+      return null;
+    }
+
+    logger.warn(
+      `OAuth token refresh failed for MCP server ${mcpServerUuid}; refusing to use expired token`,
+      error,
+    );
+    return null;
+  }
+}
+
+export async function clearOAuthTokensOnAuthFailure(
+  mcpServerUuid: string,
+  error: unknown,
+) {
+  if (!isInvalidOAuthCredentialError(error)) {
+    return false;
+  }
+
+  await clearOAuthCredentialsForServer(mcpServerUuid, "tokens");
+  logger.warn(
+    `Cleared OAuth tokens after upstream auth failure for MCP server ${mcpServerUuid}; reauthorization is required`,
+  );
+  return true;
+}

--- a/apps/backend/src/trpc/oauth.impl.ts
+++ b/apps/backend/src/trpc/oauth.impl.ts
@@ -1,4 +1,6 @@
 import {
+  ClearOAuthSessionRequestSchema,
+  ClearOAuthSessionResponseSchema,
   GetOAuthSessionRequestSchema,
   GetOAuthSessionResponseSchema,
   UpsertOAuthSessionRequestSchema,
@@ -8,14 +10,77 @@ import { z } from "zod";
 
 import logger from "@/utils/logger";
 
-import { oauthSessionsRepository } from "../db/repositories";
+import {
+  mcpServersRepository,
+  oauthSessionsRepository,
+} from "../db/repositories";
 import { OAuthSessionsSerializer } from "../db/serializers";
+
+const hasOwn = <T extends object, K extends PropertyKey>(
+  input: T,
+  key: K,
+): input is T & Record<K, unknown> =>
+  Object.prototype.hasOwnProperty.call(input, key);
+
+async function findAccessibleServer(mcpServerUuid: string, userId: string) {
+  const server = await mcpServersRepository.findByUuid(mcpServerUuid);
+
+  if (!server) {
+    return {
+      success: false as const,
+      message: "MCP server not found",
+    };
+  }
+
+  if (server.user_id && server.user_id !== userId) {
+    return {
+      success: false as const,
+      message:
+        "Access denied: You can only access OAuth sessions for servers you own",
+    };
+  }
+
+  return {
+    success: true as const,
+    server,
+  };
+}
+
+async function findMutableServer(mcpServerUuid: string, userId: string) {
+  const result = await findAccessibleServer(mcpServerUuid, userId);
+
+  if (!result.success) {
+    return result;
+  }
+
+  if (result.server.user_id === null) {
+    return {
+      success: false as const,
+      message:
+        "OAuth credentials for public MCP servers cannot be modified from a user session",
+    };
+  }
+
+  return result;
+}
 
 export const oauthImplementations = {
   get: async (
     input: z.infer<typeof GetOAuthSessionRequestSchema>,
+    userId: string,
   ): Promise<z.infer<typeof GetOAuthSessionResponseSchema>> => {
     try {
+      const serverAccess = await findAccessibleServer(
+        input.mcp_server_uuid,
+        userId,
+      );
+      if (!serverAccess.success) {
+        return {
+          success: false as const,
+          message: serverAccess.message,
+        };
+      }
+
       const session = await oauthSessionsRepository.findByMcpServerUuid(
         input.mcp_server_uuid,
       );
@@ -43,15 +108,35 @@ export const oauthImplementations = {
 
   upsert: async (
     input: z.infer<typeof UpsertOAuthSessionRequestSchema>,
+    userId: string,
   ): Promise<z.infer<typeof UpsertOAuthSessionResponseSchema>> => {
     try {
+      const serverAccess = await findMutableServer(
+        input.mcp_server_uuid,
+        userId,
+      );
+      if (!serverAccess.success) {
+        return {
+          success: false as const,
+          error: serverAccess.message,
+        };
+      }
+
       const session = await oauthSessionsRepository.upsert({
         mcp_server_uuid: input.mcp_server_uuid,
-        ...(input.client_information && {
+        ...(hasOwn(input, "client_information") && {
           client_information: input.client_information,
         }),
-        ...(input.tokens && { tokens: input.tokens }),
-        ...(input.code_verifier && { code_verifier: input.code_verifier }),
+        ...(hasOwn(input, "tokens") && { tokens: input.tokens }),
+        ...(hasOwn(input, "code_verifier") && {
+          code_verifier: input.code_verifier,
+        }),
+        ...(hasOwn(input, "tokens_obtained_at") && {
+          tokens_obtained_at: input.tokens_obtained_at,
+        }),
+        ...(hasOwn(input, "token_expires_at") && {
+          token_expires_at: input.token_expires_at,
+        }),
       });
 
       if (!session) {
@@ -68,6 +153,40 @@ export const oauthImplementations = {
       };
     } catch (error) {
       logger.error("Error upserting OAuth session:", error);
+      return {
+        success: false as const,
+        error: error instanceof Error ? error.message : "Internal server error",
+      };
+    }
+  },
+
+  clear: async (
+    input: z.infer<typeof ClearOAuthSessionRequestSchema>,
+    userId: string,
+  ): Promise<z.infer<typeof ClearOAuthSessionResponseSchema>> => {
+    try {
+      const serverAccess = await findMutableServer(
+        input.mcp_server_uuid,
+        userId,
+      );
+      if (!serverAccess.success) {
+        return {
+          success: false as const,
+          error: serverAccess.message,
+        };
+      }
+
+      await oauthSessionsRepository.clearByMcpServerUuid(
+        input.mcp_server_uuid,
+        input.scope,
+      );
+
+      return {
+        success: true as const,
+        message: "OAuth credentials cleared successfully",
+      };
+    } catch (error) {
+      logger.error("Error clearing OAuth credentials:", error);
       return {
         success: false as const,
         error: error instanceof Error ? error.message : "Internal server error",

--- a/apps/frontend/components/OAuthCallback.tsx
+++ b/apps/frontend/components/OAuthCallback.tsx
@@ -23,13 +23,36 @@ const OAuthCallback = () => {
 
       const params = new URLSearchParams(window.location.search);
       const code = params.get("code");
+      const state = params.get("state");
       const serverUrl = sessionStorage.getItem(SESSION_KEYS.SERVER_URL);
       const mcpServerUuid = sessionStorage.getItem(
         SESSION_KEYS.MCP_SERVER_UUID,
       );
 
-      if (!code || !serverUrl || !mcpServerUuid) {
+      const clearPendingOAuth = async () => {
+        if (serverUrl) {
+          sessionStorage.removeItem(
+            getServerSpecificKey(SESSION_KEYS.CODE_VERIFIER, serverUrl),
+          );
+          sessionStorage.removeItem(
+            getServerSpecificKey(SESSION_KEYS.OAUTH_STATE, serverUrl),
+          );
+        }
+        if (mcpServerUuid) {
+          try {
+            await vanillaTrpcClient.frontend.oauth.clear.mutate({
+              mcp_server_uuid: mcpServerUuid,
+              scope: "verifier",
+            });
+          } catch (clearError) {
+            console.error("Failed to clear OAuth verifier:", clearError);
+          }
+        }
+      };
+
+      if (!code || !state || !serverUrl || !mcpServerUuid) {
         console.error("Missing required OAuth parameters");
+        await clearPendingOAuth();
         window.location.href = "/mcp-servers";
         return;
       }
@@ -37,6 +60,10 @@ const OAuthCallback = () => {
       try {
         // Create auth provider with existing server UUID and URL
         const authProvider = createAuthProvider(mcpServerUuid, serverUrl);
+
+        if (!authProvider.validateState(state)) {
+          throw new Error("OAuth state mismatch");
+        }
 
         // Complete the OAuth flow
         const result = await auth(authProvider, {
@@ -63,7 +90,8 @@ const OAuthCallback = () => {
 
         const clientInformation = sessionStorage.getItem(clientInformationKey);
         const tokens = sessionStorage.getItem(tokensKey);
-        const codeVerifier = sessionStorage.getItem(codeVerifierKey);
+        const parsedTokens = tokens ? JSON.parse(tokens) : undefined;
+        const tokensObtainedAt = parsedTokens ? new Date() : null;
 
         // Save OAuth session in database using tRPC
         await vanillaTrpcClient.frontend.oauth.upsert.mutate({
@@ -71,14 +99,24 @@ const OAuthCallback = () => {
           client_information: clientInformation
             ? JSON.parse(clientInformation)
             : undefined,
-          tokens: tokens ? JSON.parse(tokens) : undefined,
-          code_verifier: codeVerifier || undefined,
+          tokens: parsedTokens,
+          code_verifier: null,
+          tokens_obtained_at: tokensObtainedAt?.toISOString() ?? null,
+          token_expires_at:
+            parsedTokens?.expires_in && tokensObtainedAt
+              ? new Date(
+                  tokensObtainedAt.getTime() + parsedTokens.expires_in * 1000,
+                ).toISOString()
+              : null,
         });
 
         // Clean up session storage
         sessionStorage.removeItem(clientInformationKey);
         sessionStorage.removeItem(tokensKey);
         sessionStorage.removeItem(codeVerifierKey);
+        sessionStorage.removeItem(
+          getServerSpecificKey(SESSION_KEYS.OAUTH_STATE, serverUrl),
+        );
         sessionStorage.removeItem(SESSION_KEYS.SERVER_URL);
         sessionStorage.removeItem(SESSION_KEYS.MCP_SERVER_UUID);
 
@@ -86,6 +124,7 @@ const OAuthCallback = () => {
         window.location.href = `/mcp-servers/${mcpServerUuid}`;
       } catch (error) {
         console.error("OAuth callback error:", error);
+        await clearPendingOAuth();
         window.location.href = "/mcp-servers";
       }
     };

--- a/apps/frontend/lib/constants.ts
+++ b/apps/frontend/lib/constants.ts
@@ -1,6 +1,7 @@
 // OAuth-related session storage keys
 export const SESSION_KEYS = {
   CODE_VERIFIER: "mcp_code_verifier",
+  OAUTH_STATE: "mcp_oauth_state",
   SERVER_URL: "mcp_server_url",
   TOKENS: "mcp_tokens",
   CLIENT_INFORMATION: "mcp_client_information",

--- a/apps/frontend/lib/oauth-provider.ts
+++ b/apps/frontend/lib/oauth-provider.ts
@@ -1,7 +1,7 @@
 import { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import {
-  OAuthClientInformation,
-  OAuthClientInformationSchema,
+  OAuthClientInformationFull,
+  OAuthClientInformationFullSchema,
   OAuthClientMetadata,
   OAuthMetadata,
   OAuthTokens,
@@ -11,6 +11,16 @@ import {
 import { getServerSpecificKey, SESSION_KEYS } from "./constants";
 import { getAppUrl } from "./env";
 import { vanillaTrpcClient } from "./trpc";
+
+const getTokenTimestamps = (tokens: OAuthTokens) => {
+  const obtainedAt = new Date();
+  return {
+    tokens_obtained_at: obtainedAt.toISOString(),
+    token_expires_at: tokens.expires_in
+      ? new Date(obtainedAt.getTime() + tokens.expires_in * 1000).toISOString()
+      : null,
+  };
+};
 
 // OAuth client provider that works with a specific MCP server
 class DbOAuthClientProvider implements OAuthClientProvider {
@@ -31,12 +41,32 @@ class DbOAuthClientProvider implements OAuthClientProvider {
   get clientMetadata(): OAuthClientMetadata {
     return {
       redirect_uris: [this.redirectUrl],
-      token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       client_name: "MetaMCP",
       client_uri: "https://github.com/metatool-ai/metamcp",
     };
+  }
+
+  state() {
+    const randomBytes = new Uint8Array(32);
+    crypto.getRandomValues(randomBytes);
+    const state = btoa(String.fromCharCode(...randomBytes))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+
+    const key = getServerSpecificKey(SESSION_KEYS.OAUTH_STATE, this.serverUrl);
+    sessionStorage.setItem(key, state);
+    return state;
+  }
+
+  validateState(returnedState: string | null) {
+    const key = getServerSpecificKey(SESSION_KEYS.OAUTH_STATE, this.serverUrl);
+    const expectedState = sessionStorage.getItem(key);
+    return (
+      !!returnedState && !!expectedState && returnedState === expectedState
+    );
   }
 
   // Check if the server exists in the database
@@ -65,7 +95,7 @@ class DbOAuthClientProvider implements OAuthClientProvider {
           mcp_server_uuid: this.mcpServerUuid,
         });
         if (result.success && result.data?.client_information) {
-          return await OAuthClientInformationSchema.parseAsync(
+          return await OAuthClientInformationFullSchema.parseAsync(
             result.data.client_information,
           );
         }
@@ -77,7 +107,7 @@ class DbOAuthClientProvider implements OAuthClientProvider {
         );
         const storedInfo = sessionStorage.getItem(key);
         if (storedInfo) {
-          return await OAuthClientInformationSchema.parseAsync(
+          return await OAuthClientInformationFullSchema.parseAsync(
             JSON.parse(storedInfo),
           );
         }
@@ -90,7 +120,7 @@ class DbOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  async saveClientInformation(clientInformation: OAuthClientInformation) {
+  async saveClientInformation(clientInformation: OAuthClientInformationFull) {
     // Save to session storage during OAuth flow
     const key = getServerSpecificKey(
       SESSION_KEYS.CLIENT_INFORMATION,
@@ -151,6 +181,7 @@ class DbOAuthClientProvider implements OAuthClientProvider {
         await vanillaTrpcClient.frontend.oauth.upsert.mutate({
           mcp_server_uuid: this.mcpServerUuid,
           tokens,
+          ...getTokenTimestamps(tokens),
         });
       } catch (error) {
         console.error("Error saving tokens to database:", error);
@@ -224,6 +255,46 @@ class DbOAuthClientProvider implements OAuthClientProvider {
     sessionStorage.removeItem(
       getServerSpecificKey(SESSION_KEYS.CODE_VERIFIER, this.serverUrl),
     );
+    sessionStorage.removeItem(
+      getServerSpecificKey(SESSION_KEYS.OAUTH_STATE, this.serverUrl),
+    );
+  }
+
+  async invalidateCredentials(scope: "all" | "client" | "tokens" | "verifier") {
+    if (scope === "all" || scope === "client") {
+      sessionStorage.removeItem(
+        getServerSpecificKey(SESSION_KEYS.CLIENT_INFORMATION, this.serverUrl),
+      );
+    }
+    if (scope === "all" || scope === "client" || scope === "tokens") {
+      sessionStorage.removeItem(
+        getServerSpecificKey(SESSION_KEYS.TOKENS, this.serverUrl),
+      );
+      sessionStorage.removeItem(
+        getServerSpecificKey(SESSION_KEYS.OAUTH_STATE, this.serverUrl),
+      );
+    }
+    if (
+      scope === "all" ||
+      scope === "client" ||
+      scope === "tokens" ||
+      scope === "verifier"
+    ) {
+      sessionStorage.removeItem(
+        getServerSpecificKey(SESSION_KEYS.CODE_VERIFIER, this.serverUrl),
+      );
+    }
+
+    if (await this.serverExists()) {
+      try {
+        await vanillaTrpcClient.frontend.oauth.clear.mutate({
+          mcp_server_uuid: this.mcpServerUuid,
+          scope,
+        });
+      } catch (error) {
+        console.error("Error invalidating OAuth credentials:", error);
+      }
+    }
   }
 }
 

--- a/packages/trpc/src/routers/frontend/oauth.ts
+++ b/packages/trpc/src/routers/frontend/oauth.ts
@@ -1,4 +1,6 @@
 import {
+  ClearOAuthSessionRequestSchema,
+  ClearOAuthSessionResponseSchema,
   GetOAuthSessionRequestSchema,
   GetOAuthSessionResponseSchema,
   UpsertOAuthSessionRequestSchema,
@@ -15,10 +17,16 @@ export const createOAuthRouter = (
   implementations: {
     get: (
       input: z.infer<typeof GetOAuthSessionRequestSchema>,
+      userId: string,
     ) => Promise<z.infer<typeof GetOAuthSessionResponseSchema>>;
     upsert: (
       input: z.infer<typeof UpsertOAuthSessionRequestSchema>,
+      userId: string,
     ) => Promise<z.infer<typeof UpsertOAuthSessionResponseSchema>>;
+    clear: (
+      input: z.infer<typeof ClearOAuthSessionRequestSchema>,
+      userId: string,
+    ) => Promise<z.infer<typeof ClearOAuthSessionResponseSchema>>;
   },
 ) => {
   return router({
@@ -26,16 +34,24 @@ export const createOAuthRouter = (
     get: protectedProcedure
       .input(GetOAuthSessionRequestSchema)
       .output(GetOAuthSessionResponseSchema)
-      .query(async ({ input }) => {
-        return await implementations.get(input);
+      .query(async ({ input, ctx }) => {
+        return await implementations.get(input, ctx.user.id);
       }),
 
     // Protected: Upsert OAuth session
     upsert: protectedProcedure
       .input(UpsertOAuthSessionRequestSchema)
       .output(UpsertOAuthSessionResponseSchema)
-      .mutation(async ({ input }) => {
-        return await implementations.upsert(input);
+      .mutation(async ({ input, ctx }) => {
+        return await implementations.upsert(input, ctx.user.id);
+      }),
+
+    // Protected: Clear OAuth credentials
+    clear: protectedProcedure
+      .input(ClearOAuthSessionRequestSchema)
+      .output(ClearOAuthSessionResponseSchema)
+      .mutation(async ({ input, ctx }) => {
+        return await implementations.clear(input, ctx.user.id);
       }),
   });
 };

--- a/packages/zod-types/src/oauth.zod.ts
+++ b/packages/zod-types/src/oauth.zod.ts
@@ -8,9 +8,31 @@ export const OAuthClientInformationSchema = z.object({
   client_secret_expires_at: z.number().optional(),
 });
 
+// OAuth Client Information Full schema (client information plus registration metadata)
+export const OAuthClientInformationFullSchema =
+  OAuthClientInformationSchema.extend({
+    redirect_uris: z.array(z.string()).optional(),
+    token_endpoint_auth_method: z.string().optional(),
+    grant_types: z.array(z.string()).optional(),
+    response_types: z.array(z.string()).optional(),
+    client_name: z.string().optional(),
+    client_uri: z.string().optional(),
+    logo_uri: z.string().optional(),
+    scope: z.string().optional(),
+    contacts: z.array(z.string()).optional(),
+    tos_uri: z.string().optional(),
+    policy_uri: z.string().optional(),
+    jwks_uri: z.string().optional(),
+    jwks: z.unknown().optional(),
+    software_id: z.string().optional(),
+    software_version: z.string().optional(),
+    software_statement: z.string().optional(),
+  });
+
 // OAuth Tokens schema (matching MCP SDK)
 export const OAuthTokensSchema = z.object({
   access_token: z.string(),
+  id_token: z.string().optional(),
   token_type: z.string(),
   expires_in: z.number().optional(),
   scope: z.string().optional(),
@@ -99,13 +121,15 @@ export const OAuthAccessTokenCreateInputSchema = z.object({
   expires_at: z.number(), // timestamp
 });
 
-// Base OAuth Session schema - client_information can be nullable since DB has default {}
+// Base OAuth Session schema for saved remote OAuth credentials.
 export const OAuthSessionSchema = z.object({
   uuid: z.string().uuid(),
   mcp_server_uuid: z.string().uuid(),
-  client_information: OAuthClientInformationSchema.nullable(),
+  client_information: OAuthClientInformationFullSchema.nullable(),
   tokens: OAuthTokensSchema.nullable(),
   code_verifier: z.string().nullable(),
+  tokens_obtained_at: z.string().datetime().nullable(),
+  token_expires_at: z.string().datetime().nullable(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
 });
@@ -131,9 +155,11 @@ export const GetOAuthSessionResponseSchema = z.union([
 // Upsert OAuth Session Request - all fields optional for updates
 export const UpsertOAuthSessionRequestSchema = z.object({
   mcp_server_uuid: z.string().uuid(),
-  client_information: OAuthClientInformationSchema.optional(),
+  client_information: OAuthClientInformationFullSchema.nullable().optional(),
   tokens: OAuthTokensSchema.nullable().optional(),
   code_verifier: z.string().nullable().optional(),
+  tokens_obtained_at: z.string().datetime().nullable().optional(),
+  token_expires_at: z.string().datetime().nullable().optional(),
 });
 
 // Upsert OAuth Session Response
@@ -149,19 +175,43 @@ export const UpsertOAuthSessionResponseSchema = z.union([
   }),
 ]);
 
+// Clear OAuth Session Request
+export const ClearOAuthSessionRequestSchema = z.object({
+  mcp_server_uuid: z.string().uuid(),
+  scope: z.enum(["all", "client", "tokens", "verifier"]).default("all"),
+});
+
+// Clear OAuth Session Response
+export const ClearOAuthSessionResponseSchema = z.union([
+  z.object({
+    success: z.literal(true),
+    message: z.string(),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string(),
+  }),
+]);
+
+const OAuthDateInputSchema = z.union([z.string().datetime(), z.date()]);
+
 // Repository-specific schemas
 export const OAuthSessionCreateInputSchema = z.object({
   mcp_server_uuid: z.string(),
-  client_information: OAuthClientInformationSchema.optional(),
+  client_information: OAuthClientInformationFullSchema.nullable().optional(),
   tokens: OAuthTokensSchema.nullable().optional(),
   code_verifier: z.string().nullable().optional(),
+  tokens_obtained_at: OAuthDateInputSchema.nullable().optional(),
+  token_expires_at: OAuthDateInputSchema.nullable().optional(),
 });
 
 export const OAuthSessionUpdateInputSchema = z.object({
   mcp_server_uuid: z.string(),
-  client_information: OAuthClientInformationSchema.optional(),
+  client_information: OAuthClientInformationFullSchema.nullable().optional(),
   tokens: OAuthTokensSchema.nullable().optional(),
   code_verifier: z.string().nullable().optional(),
+  tokens_obtained_at: OAuthDateInputSchema.nullable().optional(),
+  token_expires_at: OAuthDateInputSchema.nullable().optional(),
 });
 
 // Export repository types
@@ -171,14 +221,19 @@ export type OAuthSessionCreateInput = z.infer<
 export type OAuthSessionUpdateInput = z.infer<
   typeof OAuthSessionUpdateInputSchema
 >;
+export type OAuthClientInformationFull = z.infer<
+  typeof OAuthClientInformationFullSchema
+>;
 
 // Database-specific schemas (raw database results with Date objects)
 export const DatabaseOAuthSessionSchema = z.object({
   uuid: z.string(),
   mcp_server_uuid: z.string(),
-  client_information: OAuthClientInformationSchema.nullable(),
+  client_information: OAuthClientInformationFullSchema.nullable(),
   tokens: OAuthTokensSchema.nullable(),
   code_verifier: z.string().nullable(),
+  tokens_obtained_at: z.date().nullable(),
+  token_expires_at: z.date().nullable(),
   created_at: z.date(),
   updated_at: z.date(),
 });
@@ -200,3 +255,4 @@ export type OAuthAccessToken = z.infer<typeof OAuthAccessTokenSchema>;
 export type OAuthAccessTokenCreateInput = z.infer<
   typeof OAuthAccessTokenCreateInputSchema
 >;
+export type OAuthTokens = z.infer<typeof OAuthTokensSchema>;


### PR DESCRIPTION
MetaMCP needs to handle protected-resource OAuth challenges, dynamic registration, PKCE state, token refresh, fail-closed token invalidation, and token persistence for Košík's streamable HTTP MCP endpoint while keeping user-owned OAuth sessions isolated.

Constraint: Košík's MCP endpoint requires protected-resource OAuth metadata, dynamic client registration with client credentials, PKCE state validation, token refresh, and persistent token lifecycle storage.
Rejected: Retrying a connection with an already rejected in-memory OAuth bearer token | it repeats the same invalid upstream request after clearing the database state.
Rejected: Falling back to an expired access token after refresh failure | it forwards a known stale credential instead of requiring reauthorization or a later successful refresh.
Rejected: Treating OAuth session rows as globally mutable by UUID | it lets another authenticated user overwrite or clear stored remote credentials.
Confidence: high
Scope-risk: moderate
Directive: Keep remote OAuth session mutations owner-scoped, preserve full OAuthClientInformationFull data, and never return expired OAuth tokens when refresh is required but unavailable or failed.
Tested: targeted backend OAuth test 5 tests; backend vitest 25 tests; targeted backend ESLint; targeted frontend ESLint; pnpm check-types; @repo/trpc build; backend build; frontend build; git diff --check; architect verification issues rechecked against current tree.
Not-tested: Live browser consent against Košík was not completed from this workspace; standalone backend tsc still fails on pre-existing unrelated namespaces.serializer and metamcp-server-pool errors.