### PR TITLE
fix(session): add recovery-error detectors for session-lost + transport-lost envelopes

### DIFF
--- a/apps/backend/src/lib/metamcp/session-error.test.ts
+++ b/apps/backend/src/lib/metamcp/session-error.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isBackendSessionLostError,
+  isBackendTransportLostError,
+  isRecoverableBackendError,
+} from "./session-error";
+
+describe("isBackendSessionLostError", () => {
+  it("matches the HTTP 404 + JSON-RPC -32600 envelope the SDK produces", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("matches the HTTP 404 + JSON-RPC -32001 variant some servers return", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"error":{"code":-32001,"message":"Session not found"},"id":"","jsonrpc":"2.0"}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("does not match unrelated 404s", () => {
+    const error = new Error("Error POSTing to endpoint (HTTP 404): Not Found");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("does not match transport disconnects (transport-lost detector handles those)", () => {
+    const error = new Error("Not connected");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("returns false for null / undefined", () => {
+    expect(isBackendSessionLostError(undefined)).toBe(false);
+    expect(isBackendSessionLostError(null)).toBe(false);
+  });
+
+  it("returns false for unrelated strings", () => {
+    expect(isBackendSessionLostError("Session not found")).toBe(false);
+    expect(isBackendSessionLostError("HTTP 404")).toBe(false);
+    expect(isBackendSessionLostError("random text")).toBe(false);
+  });
+
+  it("matches a string throwable carrying the full envelope", () => {
+    const message =
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}';
+    expect(isBackendSessionLostError(message)).toBe(true);
+  });
+
+  it("matches when the session-lost error is wrapped via .cause", () => {
+    const inner = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    const outer = new Error("Failed to dispatch tool call", { cause: inner });
+    expect(isBackendSessionLostError(outer)).toBe(true);
+  });
+
+  it("matches when wrapped two layers deep via .cause", () => {
+    const innermost = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"}}',
+    );
+    const mid = new Error("Transport rejection", { cause: innermost });
+    const outer = new Error("Outer wrap", { cause: mid });
+    expect(isBackendSessionLostError(outer)).toBe(true);
+  });
+
+  it("matches a JSON-RPC error envelope passed as a plain object", () => {
+    // Some rejection paths surface the parsed RPC error envelope directly
+    // rather than the SDK's wrapped Error. The detector inspects the
+    // structured payload as well as the rendered message.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32600, message: "Session not found" },
+    };
+    expect(isBackendSessionLostError(envelope)).toBe(true);
+  });
+
+  it("matches an Error whose .code carries -32001 even when the message is sparse", () => {
+    const error = Object.assign(new Error("Session not found"), {
+      code: -32001,
+    });
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("falls back to String(error) for objects with only toString()", () => {
+    class CustomThrowable {
+      toString() {
+        return 'Error POSTing to endpoint (HTTP 404): {"error":{"code":-32600,"message":"Session not found"}}';
+      }
+    }
+    expect(isBackendSessionLostError(new CustomThrowable())).toBe(true);
+  });
+
+  it("does not match objects with unrelated -32600 contexts", () => {
+    // -32600 alone (without 'Session not found') is the JSON-RPC "Invalid
+    // Request" code and means many things. Don't false-positive on it.
+    const error = new Error("MCP error -32600: Invalid Request");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("handles circular cause chains without infinite-looping", () => {
+    const a = new Error("Wrapper a") as Error & { cause?: unknown };
+    const b = new Error("Wrapper b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isBackendSessionLostError(a)).toBe(false);
+  });
+});
+
+describe("isBackendTransportLostError", () => {
+  it("matches the bare SDK 'Not connected' Error", () => {
+    // Protocol.request() in the MCP TS SDK rejects with exactly this
+    // message when the underlying transport has been torn down.
+    const error = new Error("Not connected");
+    expect(isBackendTransportLostError(error)).toBe(true);
+  });
+
+  it("matches a 'Not connected' string throwable", () => {
+    expect(isBackendTransportLostError("Not connected")).toBe(true);
+  });
+
+  it("matches the consumer-side -32603 envelope MetaMCP returns to Claude.ai / n8n", () => {
+    // Production observation 2026-05-14: consumer-side connectors see
+    // the tRPC bridge's wrapped envelope rather than the raw SDK Error.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32603, message: "Not connected" },
+    };
+    expect(isBackendTransportLostError(envelope)).toBe(true);
+  });
+
+  it("matches when the transport-lost error is wrapped via .cause", () => {
+    const inner = new Error("Not connected");
+    const outer = new Error("Tool dispatch rejected", { cause: inner });
+    expect(isBackendTransportLostError(outer)).toBe(true);
+  });
+
+  it("matches when wrapped two layers deep via .cause", () => {
+    const innermost = new Error("Not connected");
+    const mid = new Error("Transport adapter rejection", { cause: innermost });
+    const outer = new Error("Outer wrap", { cause: mid });
+    expect(isBackendTransportLostError(outer)).toBe(true);
+  });
+
+  it("matches Error with .code -32603 + 'Not connected' message", () => {
+    const error = Object.assign(new Error("Not connected"), { code: -32603 });
+    expect(isBackendTransportLostError(error)).toBe(true);
+  });
+
+  it("does not false-positive on unrelated -32603 'Internal error' envelopes", () => {
+    // Bare -32603 is JSON-RPC "Internal error" and covers many flows.
+    // Detector only fires when paired with the 'Not connected' marker.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "x",
+      error: { code: -32603, message: "Internal error" },
+    };
+    expect(isBackendTransportLostError(envelope)).toBe(false);
+  });
+
+  it("does not match session-not-found envelopes (those go to the session-lost detector)", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isBackendTransportLostError(error)).toBe(false);
+  });
+
+  it("returns false for null / undefined / unrelated strings", () => {
+    expect(isBackendTransportLostError(undefined)).toBe(false);
+    expect(isBackendTransportLostError(null)).toBe(false);
+    expect(isBackendTransportLostError("just some text")).toBe(false);
+    expect(isBackendTransportLostError(new Error("Timeout"))).toBe(false);
+  });
+
+  it("handles circular .cause chains without infinite-looping", () => {
+    const a = new Error("Wrapper a") as Error & { cause?: unknown };
+    const b = new Error("Wrapper b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isBackendTransportLostError(a)).toBe(false);
+  });
+
+  it("falls back to String(error) for custom throwables", () => {
+    class CustomTransportError {
+      toString() {
+        return "Not connected";
+      }
+    }
+    expect(isBackendTransportLostError(new CustomTransportError())).toBe(true);
+  });
+});
+
+describe("isRecoverableBackendError", () => {
+  it("fires on session-not-found envelopes", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isRecoverableBackendError(error)).toBe(true);
+  });
+
+  it("fires on transport-disconnect envelopes", () => {
+    expect(isRecoverableBackendError(new Error("Not connected"))).toBe(true);
+  });
+
+  it("fires on the consumer-side -32603 envelope (2026-05-14 production case)", () => {
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32603, message: "Not connected" },
+    };
+    expect(isRecoverableBackendError(envelope)).toBe(true);
+  });
+
+  it("does not false-positive on unrelated errors", () => {
+    expect(isRecoverableBackendError(new Error("Timeout"))).toBe(false);
+    expect(isRecoverableBackendError(undefined)).toBe(false);
+    expect(
+      isRecoverableBackendError({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal error" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/lib/metamcp/session-error.ts
+++ b/apps/backend/src/lib/metamcp/session-error.ts
@@ -1,0 +1,290 @@
+/**
+ * Detect errors that indicate the backend MCP server's session registry no
+ * longer knows our Mcp-Session-Id. Per the MCP Streamable HTTP spec, the
+ * backend SHOULD respond with HTTP 404 when it cannot find the session; most
+ * SDKs also surface a JSON-RPC error body with code -32001 or -32600 and
+ * message "Session not found".
+ *
+ * The MCP TypeScript SDK's StreamableHTTPClientTransport wraps this as a
+ * generic Error whose message embeds the HTTP status and raw JSON-RPC body,
+ * so we match on substrings. Example:
+ *
+ *   Error POSTing to endpoint (HTTP 404):
+ *   {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}
+ *
+ * Production observation 2026-05-08: in some flows the SDK error reaches us
+ * wrapped (e.g. via `.cause` from a higher-layer handler, or stringified
+ * after passing through a non-Error rejection). The simple
+ * `error.message.includes(...)` check missed all 138 events emitted between
+ * a backend container restart and a manual MetaMCP restart, even though the
+ * rendered string clearly contained all three matched substrings. To prevent
+ * that gap from re-opening on the next backend deploy, this detector now:
+ *
+ *   1. Walks the `.cause` chain on Error inputs (max depth 8).
+ *   2. Falls back to `String(error)` for non-Error throwables (some SDK
+ *      paths reject with plain objects, McpError wrappers, or strings).
+ *   3. Inspects a numeric/string `.code` field on object inputs (some
+ *      RPC layers strip the message but preserve the code).
+ *
+ * When this fires, the cached backend connection is dead: MetaMCP must drop
+ * it, send a new `initialize`, and replay the failed request. The MCP spec
+ * states the client MUST start a new session in response to HTTP 404, so
+ * this is the normative recovery path, not a workaround.
+ */
+
+const SESSION_NOT_FOUND = "Session not found";
+const HTTP_404 = "HTTP 404";
+const RPC_CODE_PATTERNS = ["-32001", "-32600"];
+const MAX_CAUSE_DEPTH = 8;
+
+// Transport-disconnect signal raised by the MCP TypeScript SDK's Protocol
+// class when a request is dispatched on a transport that has already been
+// torn down. Produced verbatim ("Not connected") whenever the cached
+// ConnectedClient's underlying StreamableHTTPClientTransport has been
+// closed — either because the backend MCP container restarted (Watchtower
+// image pull, manual `docker restart`, OOM kill) or because the SDK's
+// session manager half-closed the stream after an idle / error condition.
+//
+// Distinct from "Session not found": the session-not-found path means the
+// backend rejected the request because its session registry doesn't know
+// our Mcp-Session-Id (recoverable by sending a new `initialize`). The
+// "Not connected" path means our local transport has no live stream to
+// send anything on (recoverable by invalidating the pool entry, opening
+// a fresh transport, and re-initializing). Both end up at the same
+// recovery action — invalidate + reconnect + retry — but the error
+// envelopes are textually disjoint, so they need separate detectors.
+const NOT_CONNECTED = "Not connected";
+// JSON-RPC code -32603 = "Internal error". MetaMCP's tRPC bridge wraps
+// the SDK-thrown "Not connected" rejection into this envelope before it
+// reaches the consumer (Claude.ai connector, n8n httpRequest node, etc.).
+// Production observation 2026-05-14: consumer-side connectors see
+// `-32603 "Not connected"` rather than the raw SDK Error, and the
+// session-lost detector misses it. Pair the code with the
+// "Not connected" message so we don't false-positive on every -32603
+// from unrelated internal-error paths.
+const RPC_CODE_TRANSPORT_LOST = "-32603";
+
+function stringMatchesSessionLost(value: string): boolean {
+  const mentionsSessionNotFound = value.includes(SESSION_NOT_FOUND);
+  const mentionsHttp404 = value.includes(HTTP_404);
+  const mentionsSessionErrorCode = RPC_CODE_PATTERNS.some((code) =>
+    value.includes(code),
+  );
+  return (
+    mentionsSessionNotFound && (mentionsHttp404 || mentionsSessionErrorCode)
+  );
+}
+
+function objectHasSessionLostCode(candidate: unknown): boolean {
+  if (typeof candidate !== "object" || candidate === null) {
+    return false;
+  }
+  const code = (candidate as { code?: unknown }).code;
+  if (typeof code === "number") {
+    return code === -32001 || code === -32600;
+  }
+  if (typeof code === "string") {
+    return code === "-32001" || code === "-32600";
+  }
+  return false;
+}
+
+function stringMatchesTransportLost(value: string): boolean {
+  // The "Not connected" substring is the load-bearing marker; the
+  // -32603 code is only a confirming signal when present in a JSON-RPC
+  // envelope. A bare "Not connected" message from the SDK is sufficient.
+  return value.includes(NOT_CONNECTED);
+}
+
+function objectHasTransportLostCode(candidate: unknown): boolean {
+  // Only match -32603 when the rendered/structured object also carries
+  // the "Not connected" marker — bare -32603 is JSON-RPC "Internal
+  // error" and covers many unrelated failure modes.
+  if (typeof candidate !== "object" || candidate === null) {
+    return false;
+  }
+  const obj = candidate as { code?: unknown; message?: unknown };
+  const code = obj.code;
+  const isTransportCode =
+    code === -32603 ||
+    code === "-32603" ||
+    (typeof code === "string" && code.includes(RPC_CODE_TRANSPORT_LOST));
+  if (!isTransportCode) {
+    return false;
+  }
+  if (
+    typeof obj.message === "string" &&
+    stringMatchesTransportLost(obj.message)
+  ) {
+    return true;
+  }
+  try {
+    return stringMatchesTransportLost(JSON.stringify(candidate));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect errors that indicate the cached backend client's transport is dead.
+ *
+ * Sibling of {@link isBackendSessionLostError}. The session-lost detector
+ * matches the backend's "I don't know your Mcp-Session-Id" response (HTTP
+ * 404 + JSON-RPC -32001/-32600 + "Session not found"). The transport-lost
+ * detector matches the SDK's local "I have no live stream to send on"
+ * rejection, surfaced as a bare `"Not connected"` Error from
+ * `Protocol.request()` and also as a `-32603 "Not connected"` JSON-RPC
+ * envelope on the consumer-facing side.
+ *
+ * When this fires, the recovery action is identical to the session-lost
+ * path: invalidate the pooled `ConnectedClient`, open a fresh transport,
+ * re-initialize, and replay the request once. The two detectors are kept
+ * separate (rather than collapsed into one OR-of-substrings function) so
+ * each has a tight predicate that doesn't false-positive on the much
+ * larger noise floor of unrelated -32603 / 404 errors.
+ *
+ * Production observation 2026-05-14: rapid-deploy cadence on the autotask
+ * MCP backend (Watchtower pulls + container restarts within a 5-min
+ * window) produced disconnect windows where the consumer-side connector
+ * saw `-32603 "Not connected"` on every call. The session-lost detector
+ * missed all of these; the recovery path in `metamcp-proxy.ts` never
+ * fired. Operator quote (2026-05-14): "It's not acceptable for having
+ * MCP servers down or needing reboots after small change applications."
+ * This detector + the matching recovery wiring in `metamcp-proxy.ts`
+ * close that gap.
+ */
+export function isBackendTransportLostError(error: unknown): boolean {
+  if (error == null) {
+    return false;
+  }
+
+  if (typeof error === "string") {
+    return stringMatchesTransportLost(error);
+  }
+
+  let current: unknown = error;
+  let depth = 0;
+  const seen = new Set<unknown>();
+  while (current != null && depth < MAX_CAUSE_DEPTH) {
+    if (seen.has(current)) {
+      // Circular .cause chain — bail out.
+      break;
+    }
+    seen.add(current);
+
+    if (current instanceof Error) {
+      if (current.message && stringMatchesTransportLost(current.message)) {
+        return true;
+      }
+      if (objectHasTransportLostCode(current)) {
+        return true;
+      }
+      current = (current as { cause?: unknown }).cause;
+      depth += 1;
+      continue;
+    }
+
+    if (typeof current === "object") {
+      const obj = current as { message?: unknown };
+      if (
+        typeof obj.message === "string" &&
+        stringMatchesTransportLost(obj.message)
+      ) {
+        return true;
+      }
+      if (objectHasTransportLostCode(current)) {
+        return true;
+      }
+      try {
+        const rendered = JSON.stringify(current);
+        if (stringMatchesTransportLost(rendered)) {
+          return true;
+        }
+      } catch {
+        // Non-serializable; fall through.
+      }
+      break;
+    }
+    break;
+  }
+
+  try {
+    return stringMatchesTransportLost(String(error));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Convenience predicate — either the session-lost OR transport-lost
+ * detector fires. Tool-call and dynamic-find recovery paths in
+ * `metamcp-proxy.ts` use this so they engage the same invalidate +
+ * reconnect + retry sequence regardless of which envelope the failure
+ * arrived in.
+ */
+export function isRecoverableBackendError(error: unknown): boolean {
+  return isBackendSessionLostError(error) || isBackendTransportLostError(error);
+}
+
+export function isBackendSessionLostError(error: unknown): boolean {
+  if (error == null) {
+    return false;
+  }
+
+  // String inputs (some rejection paths surface a bare string).
+  if (typeof error === "string") {
+    return stringMatchesSessionLost(error);
+  }
+
+  // Walk Error.cause chain — match any link in the chain.
+  let current: unknown = error;
+  let depth = 0;
+  while (current != null && depth < MAX_CAUSE_DEPTH) {
+    if (current instanceof Error) {
+      if (current.message && stringMatchesSessionLost(current.message)) {
+        return true;
+      }
+      if (objectHasSessionLostCode(current)) {
+        return true;
+      }
+      current = (current as { cause?: unknown }).cause;
+      depth += 1;
+      continue;
+    }
+    if (typeof current === "object") {
+      // Plain object (e.g. JSON-RPC error envelope): inspect message + code.
+      const obj = current as { message?: unknown; code?: unknown };
+      if (
+        typeof obj.message === "string" &&
+        stringMatchesSessionLost(obj.message)
+      ) {
+        return true;
+      }
+      if (objectHasSessionLostCode(obj)) {
+        return true;
+      }
+      // Last-ditch: render the whole object and substring-match. Catches
+      // shapes like `{ jsonrpc, id, error: { code, message } }` where the
+      // session-not-found markers live one level deep.
+      try {
+        const rendered = JSON.stringify(current);
+        if (stringMatchesSessionLost(rendered)) {
+          return true;
+        }
+      } catch {
+        // Circular structure or non-serializable; ignore.
+      }
+      break;
+    }
+    break;
+  }
+
+  // Final fallback: stringify the original input. Covers throwables that
+  // implement only `toString()` (e.g. some legacy transports emit a
+  // class with a meaningful String(...) representation but no message).
+  try {
+    return stringMatchesSessionLost(String(error));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Provides the detector library used by the recovery path opened in **#283** ("Re-initialize backend session when Streamable HTTP backend returns HTTP 404 'Session not found'"). Lands as a standalone, no-touch-on-other-files contribution so reviewers can evaluate the detectors independently of the recovery wiring.

## Why

When a backend MCP server using Streamable HTTP loses session state — either because its session registry got wiped (container restart → "Session not found" 404) or because the cached transport itself went away (Watchtower pull → "Not connected" SDK rejection) — MetaMCP's pool still holds the dead reference and every subsequent call fails verbatim. The right recovery is identical for both cases (invalidate pool + open fresh transport + initialize + replay once), but the error envelopes are textually disjoint.

PR #283 implements the recovery wiring for the session-not-found path. This PR provides the detector library that powers it AND extends to the transport-lost case so a single, shared predicate covers both failure modes.

## Detectors

Two tight predicates + a convenience union (`apps/backend/src/lib/metamcp/session-error.ts`):

- **`isBackendSessionLostError(error)`** — matches the backend's "I don't know your Mcp-Session-Id" envelope (HTTP 404 + JSON-RPC -32001/-32600 + "Session not found"). Per the MCP Streamable HTTP spec, the client MUST start a new session on 404, so this is the normative recovery signal.
- **`isBackendTransportLostError(error)`** — matches the SDK `Protocol`'s "Not connected" rejection raised when a request is dispatched on a transport that has been torn down. Also matches the wrapped `-32603 "Not connected"` JSON-RPC envelope tRPC-bridge consumers see (Claude.ai connectors, n8n httpRequest nodes, etc).
- **`isRecoverableBackendError(error)`** — fires on either of the above. Intended as the predicate at the recovery callsite.

### Hardening (shared by both)

- Walk `Error.cause` chains up to depth 8 (some SDK paths reject with the meaningful error one or two layers deep).
- Handle string throwables (some legacy transports reject with bare strings).
- Inspect numeric/string `.code` on object inputs (some RPC layers strip the message but preserve the code).
- Pair the JSON-RPC code with the message marker on transport-lost detection so we don't false-positive on the much larger noise floor of unrelated `-32603` "Internal error" envelopes.
- Last-ditch `JSON.stringify` fallback to catch nested-envelope shapes.
- Detect circular `.cause` chains via a seen-set (transport-lost) or bounded depth (session-lost).

### Why two detectors instead of one

Session-lost = backend rejected our session id (recovery: send a new `initialize`).
Transport-lost = local transport has no live stream (recovery: invalidate pool entry, open fresh transport, initialize).

Both end up at the same recovery action, but the error envelopes are textually disjoint — separate tight predicates prevent false-positives more reliably than one OR-of-substrings union.

## Tests

29 vitest cases (`apps/backend/src/lib/metamcp/session-error.test.ts`) cover both detectors + the union predicate:

- session-lost: HTTP 404 + -32600 / -32001 envelopes; false-on-unrelated-404s; false-on-transport-disconnects (sibling handles those); null/undefined; string throwables; wrapped via `.cause` one + two layers; plain-object envelopes; `.code` carrying -32001 with sparse message; custom toString-only throwables; no false-positive on unrelated -32600 "Invalid Request"; circular chains.
- transport-lost: bare SDK "Not connected"; string throwable; consumer-side -32603 + "Not connected" envelope; wrapped one + two layers; Error with `.code` -32603 + matching message; no false-positive on bare -32603 "Internal error"; no false-positive on session-not-found envelopes; null/undefined/unrelated; custom toString-only throwables; circular chains.
- union predicate: fires on each family + no false-positives.

```
$ pnpm vitest run src/lib/metamcp/session-error.test.ts

✓ src/lib/metamcp/session-error.test.ts (29 tests) 3ms

 Test Files  1 passed (1)
      Tests  29 passed (29)
```

ESLint clean. TypeScript clean on the touched files.

## Production observation

Originally shipped in the Umbrella IT Group downstream fork as a pair of PRs (commits available for cherry-pick if reviewing):

- **[Umbrella-IT-Group/metamcp#12](https://github.com/Umbrella-IT-Group/metamcp/pull/12)** — Harden the session-lost detector after a production case where the SDK error reached us wrapped via `.cause` (138 events emitted between a backend container restart and a manual MetaMCP restart, all missed by the simple `message.includes(...)` check).
- **[Umbrella-IT-Group/metamcp#13](https://github.com/Umbrella-IT-Group/metamcp/pull/13)** — Add the transport-lost detector after rapid backend deploys (Watchtower image pulls) produced disconnect windows where consumer-side connectors saw `-32603 "Not connected"` on every call.

Operator escalation that drove #13 (2026-05-14): _"It's not acceptable for having MCP servers down or needing reboots after small change applications."_ The "documented workaround" of `sudo docker restart metamcp` is being retired.

## Companion PR

**[#283](https://github.com/metatool-ai/metamcp/pull/283)** introduces the recovery wiring in `metamcp-proxy.ts` that consumes `isBackendSessionLostError`. If #283 lands first, this PR layers trivially on top. If this PR lands first, #283's recovery wiring can flip to `isRecoverableBackendError` to pick up the transport-lost path with zero additional code.

Either order works; the detectors are pure functions with no dependency on the recovery hook callsite.

## Maintenance posture

Contributing upstream per good-citizenship — the fix is already live in our fork (Umbrella-IT-Group/metamcp `umbrella` branch). Queued here if the maintainer revives, and a discoverable reference for other downstream forks that hit the same disconnect pattern.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>