### PR TITLE
fix(oauth): atomic upsert + SSR-safe OAuth provider (closes #296, #297)

### DIFF
--- a/apps/backend/src/db/repositories/__tests__/oauth-sessions.repo.test.ts
+++ b/apps/backend/src/db/repositories/__tests__/oauth-sessions.repo.test.ts
@@ -1,0 +1,167 @@
+import type {
+  OAuthClientInformation,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const valuesCalls: any[] = [];
+const onConflictSetCalls: any[] = [];
+const onConflictTargetCalls: any[] = [];
+
+// In-memory store keyed by mcp_server_uuid that mimics
+// `INSERT ... ON CONFLICT (mcp_server_uuid) DO UPDATE SET ...` semantics.
+// Tests then assert both the persisted result AND the call shape passed
+// to Drizzle, so we pin the conditional-spread behaviour directly.
+const store = new Map<string, any>();
+
+vi.mock("../../index", () => {
+  return {
+    db: {
+      insert: () => ({
+        values: (values: any) => {
+          valuesCalls.push(values);
+          return {
+            onConflictDoUpdate: ({
+              target,
+              set,
+            }: {
+              target: unknown;
+              set: any;
+            }) => {
+              onConflictTargetCalls.push(target);
+              onConflictSetCalls.push(set);
+              return {
+                returning: async () => {
+                  const key = values.mcp_server_uuid;
+                  const now = new Date();
+                  const existing = store.get(key);
+                  if (existing) {
+                    // ON CONFLICT DO UPDATE: merge only the keys present in `set`.
+                    // Strip the sql`NOW()` updated_at because the fake can't
+                    // execute SQL — overwrite with a Date instead.
+                    const { updated_at: _ignored, ...applicable } = set;
+                    const updated = {
+                      ...existing,
+                      ...applicable,
+                      updated_at: now,
+                    };
+                    store.set(key, updated);
+                    return [updated];
+                  }
+                  // Fresh insert: schema-defaulted columns are filled with
+                  // their declared defaults (client_information => {}).
+                  const row = {
+                    uuid: `uuid-${store.size}`,
+                    mcp_server_uuid: values.mcp_server_uuid,
+                    client_information: values.client_information ?? {},
+                    tokens: values.tokens ?? null,
+                    code_verifier: values.code_verifier ?? null,
+                    created_at: now,
+                    updated_at: now,
+                  };
+                  store.set(key, row);
+                  return [row];
+                },
+              };
+            },
+          };
+        },
+      }),
+    },
+  };
+});
+
+// Import AFTER vi.mock so the repo binds to the fake db.
+const { OAuthSessionsRepository } = await import("../oauth-sessions.repo");
+
+describe("OAuthSessionsRepository.upsert", () => {
+  const repo = new OAuthSessionsRepository();
+  const serverId = "00000000-0000-0000-0000-000000000001";
+
+  beforeEach(() => {
+    store.clear();
+    valuesCalls.length = 0;
+    onConflictSetCalls.length = 0;
+    onConflictTargetCalls.length = 0;
+  });
+
+  it("uses a single ON CONFLICT statement (not check-then-insert)", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      client_information: { client_id: "client-A" } as OAuthClientInformation,
+    });
+
+    // Exactly one insert chain per call: this is what makes the upsert
+    // atomic and removes the SELECT-then-INSERT race window.
+    expect(valuesCalls).toHaveLength(1);
+    expect(onConflictSetCalls).toHaveLength(1);
+    expect(onConflictTargetCalls[0]).toBeDefined();
+  });
+
+  it("two sequential upserts produce a single row whose values reflect the last call", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      client_information: { client_id: "client-A" } as OAuthClientInformation,
+    });
+    const second = await repo.upsert({
+      mcp_server_uuid: serverId,
+      client_information: { client_id: "client-B" } as OAuthClientInformation,
+    });
+
+    expect(store.size).toBe(1);
+    expect(second.client_information).toEqual({ client_id: "client-B" });
+  });
+
+  it("partial upsert with only tokens does not write code_verifier into the SET clause", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      tokens: { access_token: "tok", token_type: "Bearer" } as OAuthTokens,
+    });
+
+    const set = onConflictSetCalls[0];
+    expect(set).toHaveProperty("tokens");
+    expect(set).not.toHaveProperty("code_verifier");
+    expect(set).not.toHaveProperty("client_information");
+  });
+
+  it("partial upsert with only code_verifier does not clear an existing tokens column", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      tokens: { access_token: "tok", token_type: "Bearer" } as OAuthTokens,
+    });
+    const second = await repo.upsert({
+      mcp_server_uuid: serverId,
+      code_verifier: "the-verifier",
+    });
+
+    expect(second.tokens).toEqual({
+      access_token: "tok",
+      token_type: "Bearer",
+    });
+    expect(second.code_verifier).toBe("the-verifier");
+
+    // Second call's SET must NOT mention tokens — that's what would have
+    // cleared the column if the conditional spread regressed.
+    const setOnSecond = onConflictSetCalls[1];
+    expect(setOnSecond).toHaveProperty("code_verifier");
+    expect(setOnSecond).not.toHaveProperty("tokens");
+    expect(setOnSecond).not.toHaveProperty("client_information");
+  });
+
+  it("partial upsert with only tokens does not clear an existing code_verifier", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      code_verifier: "the-verifier",
+    });
+    const second = await repo.upsert({
+      mcp_server_uuid: serverId,
+      tokens: { access_token: "tok", token_type: "Bearer" } as OAuthTokens,
+    });
+
+    expect(second.code_verifier).toBe("the-verifier");
+    expect(second.tokens).toEqual({
+      access_token: "tok",
+      token_type: "Bearer",
+    });
+  });
+});

--- a/apps/backend/src/db/repositories/oauth-sessions.repo.ts
+++ b/apps/backend/src/db/repositories/oauth-sessions.repo.ts
@@ -57,22 +57,40 @@ export class OAuthSessionsRepository {
   }
 
   async upsert(input: OAuthSessionUpdateInput): Promise<DatabaseOAuthSession> {
-    // Check if session exists
-    const existingSession = await this.findByMcpServerUuid(
-      input.mcp_server_uuid,
-    );
+    // Single-statement atomic upsert. Concurrent callers for the same
+    // mcp_server_uuid resolve via ON CONFLICT instead of racing a
+    // SELECT-then-INSERT, which previously crashed the loser with a
+    // unique-constraint violation. Only fields present on `input` are written
+    // so a partial update (e.g. tokens only) does not clear unrelated columns
+    // such as code_verifier.
+    const [row] = await db
+      .insert(oauthSessionsTable)
+      .values({
+        mcp_server_uuid: input.mcp_server_uuid,
+        ...(input.client_information && {
+          client_information: input.client_information,
+        }),
+        ...(input.tokens && { tokens: input.tokens }),
+        ...(input.code_verifier && { code_verifier: input.code_verifier }),
+      })
+      .onConflictDoUpdate({
+        target: oauthSessionsTable.mcp_server_uuid,
+        set: {
+          ...(input.client_information && {
+            client_information: input.client_information,
+          }),
+          ...(input.tokens && { tokens: input.tokens }),
+          ...(input.code_verifier && { code_verifier: input.code_verifier }),
+          updated_at: sql`NOW()`,
+        },
+      })
+      .returning();
 
-    if (existingSession) {
-      // Update existing session
-      const updatedSession = await this.update(input);
-      if (!updatedSession) {
-        throw new Error("Failed to update OAuth session");
-      }
-      return updatedSession;
-    } else {
-      // Create new session
-      return await this.create(input);
+    if (!row) {
+      throw new Error("Failed to upsert OAuth session");
     }
+
+    return row;
   }
 
   async deleteByMcpServerUuid(

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/[uuid]/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/[uuid]/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { notFound, useRouter } from "next/navigation";
-import { use, useEffect, useState } from "react";
+import { use, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { EditMcpServer } from "@/components/edit-mcp-server";
@@ -161,8 +161,14 @@ export default function McpServerDetailPage({
     ),
   });
 
-  // Auto-connect when hook is enabled and not already connected
+  // Auto-connect when hook is enabled and not already connected.
+  // Guarded against React Strict Mode's intentional double-invocation of
+  // effects in dev: without the ref, both fires would race two concurrent
+  // OAuth dynamic registrations and the browser/DB would disagree on
+  // client_id, breaking token exchange.
+  const didAutoConnect = useRef(false);
   useEffect(() => {
+    if (didAutoConnect.current) return;
     if (
       connection &&
       server &&
@@ -170,6 +176,7 @@ export default function McpServerDetailPage({
       server.error_status !== McpServerErrorStatusEnum.Enum.ERROR &&
       connection.connectionStatus === "disconnected"
     ) {
+      didAutoConnect.current = true;
       connection.connect();
     }
   }, [server, connection, isLoading]);

--- a/apps/frontend/lib/oauth-provider.ts
+++ b/apps/frontend/lib/oauth-provider.ts
@@ -20,8 +20,19 @@ class DbOAuthClientProvider implements OAuthClientProvider {
   constructor(mcpServerUuid: string, serverUrl: string) {
     this.mcpServerUuid = mcpServerUuid;
     this.serverUrl = serverUrl;
-    // Save the server URL to session storage for consistency
-    sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl);
+    // No sessionStorage access here: the constructor runs during Next.js SSR
+    // for the MCP server detail page, where sessionStorage is undefined.
+    // The SERVER_URL seed is deferred to ensureServerUrlStored(), called by
+    // the OAuth-flow methods below, all of which are invoked client-side.
+  }
+
+  // Seeds SESSION_KEYS.SERVER_URL on first invocation in the browser. The
+  // OAuth callback page reads this key to recover the upstream serverUrl, so
+  // it must be set before redirectToAuthorization sends the user away. Safe
+  // to call repeatedly; a no-op on the server.
+  private ensureServerUrlStored() {
+    if (typeof window === "undefined") return;
+    sessionStorage.setItem(SESSION_KEYS.SERVER_URL, this.serverUrl);
   }
 
   get redirectUrl() {
@@ -91,6 +102,7 @@ class DbOAuthClientProvider implements OAuthClientProvider {
   }
 
   async saveClientInformation(clientInformation: OAuthClientInformation) {
+    this.ensureServerUrlStored();
     // Save to session storage during OAuth flow
     const key = getServerSpecificKey(
       SESSION_KEYS.CLIENT_INFORMATION,
@@ -159,10 +171,12 @@ class DbOAuthClientProvider implements OAuthClientProvider {
   }
 
   redirectToAuthorization(authorizationUrl: URL) {
+    this.ensureServerUrlStored();
     window.location.href = authorizationUrl.href;
   }
 
   async saveCodeVerifier(codeVerifier: string) {
+    this.ensureServerUrlStored();
     // Save to session storage during OAuth flow
     const key = getServerSpecificKey(
       SESSION_KEYS.CODE_VERIFIER,

--- a/packages/zod-types/src/oauth.zod.ts
+++ b/packages/zod-types/src/oauth.zod.ts
@@ -128,12 +128,16 @@ export const GetOAuthSessionResponseSchema = z.union([
   }),
 ]);
 
-// Upsert OAuth Session Request - all fields optional for updates
+// Upsert OAuth Session Request - all fields optional for updates.
+// `tokens` and `code_verifier` are NOT nullable: the atomic upsert in
+// `OAuthSessionsRepository.upsert` drops nullish values via the conditional
+// spread (omit = "do not touch"), so allowing `null` here would advertise a
+// "clear this column" contract the implementation does not honour.
 export const UpsertOAuthSessionRequestSchema = z.object({
   mcp_server_uuid: z.string().uuid(),
   client_information: OAuthClientInformationSchema.optional(),
-  tokens: OAuthTokensSchema.nullable().optional(),
-  code_verifier: z.string().nullable().optional(),
+  tokens: OAuthTokensSchema.optional(),
+  code_verifier: z.string().optional(),
 });
 
 // Upsert OAuth Session Response
@@ -149,19 +153,21 @@ export const UpsertOAuthSessionResponseSchema = z.union([
   }),
 ]);
 
-// Repository-specific schemas
+// Repository-specific schemas. `tokens` and `code_verifier` mirror the upsert
+// contract above: omitted means "leave the column alone"; `null` is not
+// accepted because the impl would silently drop it.
 export const OAuthSessionCreateInputSchema = z.object({
   mcp_server_uuid: z.string(),
   client_information: OAuthClientInformationSchema.optional(),
-  tokens: OAuthTokensSchema.nullable().optional(),
-  code_verifier: z.string().nullable().optional(),
+  tokens: OAuthTokensSchema.optional(),
+  code_verifier: z.string().optional(),
 });
 
 export const OAuthSessionUpdateInputSchema = z.object({
   mcp_server_uuid: z.string(),
   client_information: OAuthClientInformationSchema.optional(),
-  tokens: OAuthTokensSchema.nullable().optional(),
-  code_verifier: z.string().nullable().optional(),
+  tokens: OAuthTokensSchema.optional(),
+  code_verifier: z.string().optional(),
 });
 
 // Export repository types


### PR DESCRIPTION
Bundles two short, orthogonal bug fixes surfaced during smoke testing of #295. Both are pre-existing in `main` and independent of the OAuth work in #295.

## Closes #296 — Atomic upsert + guarded auto-connect

`OAuthSessionsRepository.upsert()` was non-atomic (check-then-insert), which races under React Strict Mode's intentional double-invocation of useEffect in dev. Two concurrent SDK dynamic registrations would each pick up `undefined` from `findByMcpServerUuid` and both attempt `create()`. The winner persists; the browser ends up using the loser's `client_id` (last assignment wins in `window.location.href`). Upstream rejects the exchange with `invalid_grant: Client ID mismatch`.

Fix is two parts:

- **Server-side:** rewrite `upsert` using Drizzle's `onConflictDoUpdate` so the operation is atomic. Mapped to update only the input fields (tokens-only call doesn't clear code_verifier and vice versa).
- **Client-side:** add a `useRef` guard on the auto-connect useEffect so Strict Mode's double-invocation does not double-fire `connection.connect()`. Manual user-initiated Connect button is unaffected.

## Closes #297 — SSR-safe DbOAuthClientProvider

`DbOAuthClientProvider`'s constructor called `sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl)`. The constructor runs during Next.js server-side render for `/mcp-servers/[uuid]`, where `sessionStorage` does not exist, throwing `ReferenceError: sessionStorage is not defined`. The page recovers on client render but the SSR error pollutes monitoring.

Fix moves the `sessionStorage.setItem` out of the constructor into a `ensureServerUrlStored()` method invoked from the first method that actually needs it. Also audited the rest of the file for any other constructor-time browser API access; none found.

## Test plan

- Backend: 2 new unit tests in `oauth-sessions.repo.test.ts` cover the atomic-upsert behaviour (sequential calls + partial inputs).
- Frontend: no test framework available today; SSR fix verified via `pnpm -F frontend build` + `next start` + visit `/mcp-servers/[uuid]` in incognito — no SSR error in browser console.
- `pnpm -F backend test` green. Backend / frontend typecheck and lint green for files touched.

## Migration

No schema migration. No new dependencies. Backward compatible — existing `upsert` callers see no behaviour change beyond the race condition disappearing.


## Follow-up (responding to code review feedback)

Tightened the upsert input schema in `packages/zod-types/src/oauth.zod.ts`: dropped the `null` union from `tokens` and `code_verifier`. Reason: the atomic upsert in the repo drops `null` silently via the conditional spread, so the schema accepting `null` gave callers a contract the implementation did not honor. Schema and impl now agree.
