### PR TITLE
feat: expose namespace description as MCP instructions

### DIFF
--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 
 import logger from "@/utils/logger";
 
+import { namespacesRepository } from "../../db/repositories/namespaces.repo";
 import { toolsImplementations } from "../../trpc/tools.impl";
 import { configService } from "../config.service";
 import { ConnectedClient } from "./client";
@@ -121,6 +122,8 @@ export const createServer = async (
     return false;
   };
 
+  const namespace = await namespacesRepository.findByUuid(namespaceUuid);
+
   const server = new Server(
     {
       name: `metamcp-unified-${namespaceUuid}`,
@@ -132,6 +135,7 @@ export const createServer = async (
         resources: {},
         tools: {},
       },
+      instructions: namespace?.description ?? undefined,
     },
   );
 


### PR DESCRIPTION
## Summary

Pass the `namespaces.description` column to the `Server` constructor as the `instructions` field of the MCP `InitializeResult`. MCP clients (Claude Desktop, Claude Code, Cursor, etc.) can then display a human-readable description of what each MetaMCP namespace offers when the connector is added or initialized.

## Why

Currently, the namespace `/metamcp/<name>/mcp` endpoint returns a generic `serverInfo` only:
```json
"serverInfo": { "name": "metamcp-unified-<uuid>", "version": "1.0.0" }
```

The `description` column already exists in the `namespaces` table and is editable from the dashboard, but it's not exposed through the MCP protocol. This PR closes that gap by forwarding it as the spec's `instructions` field, which clients use to surface the purpose of a server to both users and LLMs.

## Changes

- `apps/backend/src/lib/metamcp/metamcp-proxy.ts`: read `namespace.description` via `namespacesRepository.findByUuid` and pass it as `instructions` in `ServerOptions`.
- 4 lines added, 1 file touched.

## Behavior

| `namespace.description` | `InitializeResult.instructions` |
| --- | --- |
| `"Analytics + BI"` | `"Analytics + BI"` |
| `NULL` | field omitted (SDK default) |

## Test plan

- [x] Smoke-tested locally: `initialize` returns `instructions` when description is set, omits the field when NULL.
- [x] Deployed to production (AlloVoisins fork) — no regressions observed, app healthy.
- [x] No DB migration required (column already exists).

## Notes

- The MCP TypeScript SDK has supported `instructions` in `ServerOptions` since early 1.x (verified on 1.16.0).
- No interaction with auth/sessions/pool — purely additive at the `Server` constructor level.