### PR TITLE
fix(mcp-server-pool): read MAX_TOTAL_CONNECTIONS from env

### DIFF
--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -61,7 +61,9 @@ export class McpServerPool {
    */
   static getInstance(defaultIdleCount: number = 1): McpServerPool {
     if (!McpServerPool.instance) {
-      McpServerPool.instance = new McpServerPool(defaultIdleCount);
+      const envMax = parseInt(process.env.MAX_TOTAL_CONNECTIONS || "", 10);
+      const maxConn = Number.isFinite(envMax) && envMax > 0 ? envMax : 100;
+      McpServerPool.instance = new McpServerPool(defaultIdleCount, maxConn);
     }
     return McpServerPool.instance;
   }


### PR DESCRIPTION
## Problem

`McpServerPool.getInstance(defaultIdleCount)` builds the singleton with `new McpServerPool(defaultIdleCount)`. The constructor's second parameter `maxTotalConnections` defaults to 100, but `getInstance` never passes it, so the 100-connection cap is effectively hardcoded with no operator knob.

For deployments fronting an HTTP/SSE backend fleet, this interacts badly with idle-session accumulation (see #294). Once `canCreateConnection()` refuses new sessions because the total has reached 100, every namespace's `tools/list` silently returns 200 OK with an empty result. The client cannot tell the gateway is saturated.

## Change

Read `MAX_TOTAL_CONNECTIONS` from `process.env` in `getInstance`. Default falls back to 100 when the variable is unset or fails to parse as a positive integer. Three lines of TypeScript, no behavior change for existing operators (the unset path is identical to the previous hardcoded one).

```ts
static getInstance(defaultIdleCount: number = 1): McpServerPool {
  if (!McpServerPool.instance) {
    const envMax = parseInt(process.env.MAX_TOTAL_CONNECTIONS || "", 10);
    const maxConn = Number.isFinite(envMax) && envMax > 0 ? envMax : 100;
    McpServerPool.instance = new McpServerPool(defaultIdleCount, maxConn);
  }
  return McpServerPool.instance;
}
```

## Why a separate PR

Closing the loop on my comment in #294. The underlying session-leak fix in #283 addresses the root cause, but a simple env knob lets operators size the pool up to whatever their fleet needs in the meantime, without forking. The two changes are complementary: #283 stops the leak; this PR lets operators run with realistic caps until that lands.

## Verification

Tested against a homelab deployment fronting 5 streamable_http/SSE backends. With `MAX_TOTAL_CONNECTIONS=500` in the container env, the singleton initializes with `maxTotalConnections=500` and the pool accepts new connections past the previous 100 limit. With the variable unset, behavior matches main verbatim.

Refs: #294