### PR TITLE
fix(proxy): invalidate-and-retry recovery in the aggregate list handlers

### DIFF
--- a/apps/backend/src/lib/metamcp/list-handler-recovery.test.ts
+++ b/apps/backend/src/lib/metamcp/list-handler-recovery.test.ts
@@ -1,0 +1,150 @@
+import { ServerParameters } from "@repo/zod-types";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConnectedClient } from "./client";
+import {
+  RecoverySessionPool,
+  requestWithSessionRecovery,
+} from "./list-handler-recovery";
+
+// The exact envelope shape the backend produces when its session died
+// (matches session-error.test.ts fixtures). isRecoverableBackendError
+// must classify it as recoverable.
+const sessionLostError = () =>
+  new Error(
+    'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}',
+  );
+
+const transportLostError = () => new Error("Not connected");
+
+const makeSession = (label: string): ConnectedClient =>
+  ({ label }) as unknown as ConnectedClient;
+
+const params = { uuid: "server-1", name: "test-server" } as ServerParameters;
+
+const makePool = (freshSession: ConnectedClient | undefined) => {
+  const pool: RecoverySessionPool = {
+    invalidateServerConnection: vi.fn().mockResolvedValue(undefined),
+    getSession: vi.fn().mockResolvedValue(freshSession),
+  };
+  return pool;
+};
+
+const baseOpts = (pool: RecoverySessionPool, session: ConnectedClient) => ({
+  pool,
+  sessionId: "session-abc",
+  serverUuid: "server-1",
+  params,
+  namespaceUuid: "ns-1",
+  operation: "tools/list",
+  serverName: "test-server",
+  session,
+});
+
+describe("requestWithSessionRecovery", () => {
+  it("returns the first attempt's result without touching the pool", async () => {
+    const session = makeSession("stale");
+    const pool = makePool(undefined);
+    const attempt = vi.fn().mockResolvedValue(["tool-a"]);
+
+    const result = await requestWithSessionRecovery({
+      ...baseOpts(pool, session),
+      attempt,
+    });
+
+    expect(result).toEqual(["tool-a"]);
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(attempt).toHaveBeenCalledWith(session);
+    expect(pool.invalidateServerConnection).not.toHaveBeenCalled();
+    expect(pool.getSession).not.toHaveBeenCalled();
+  });
+
+  it("invalidates, re-acquires, and retries once on a session-lost envelope", async () => {
+    const stale = makeSession("stale");
+    const fresh = makeSession("fresh");
+    const pool = makePool(fresh);
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(sessionLostError())
+      .mockResolvedValueOnce(["tool-b"]);
+    const onFreshSession = vi.fn();
+
+    const result = await requestWithSessionRecovery({
+      ...baseOpts(pool, stale),
+      attempt,
+      onFreshSession,
+    });
+
+    expect(result).toEqual(["tool-b"]);
+    expect(pool.invalidateServerConnection).toHaveBeenCalledWith(
+      "session-abc",
+      "server-1",
+    );
+    expect(pool.getSession).toHaveBeenCalledWith(
+      "session-abc",
+      "server-1",
+      params,
+      "ns-1",
+    );
+    expect(onFreshSession).toHaveBeenCalledWith(fresh);
+    expect(attempt).toHaveBeenNthCalledWith(1, stale);
+    expect(attempt).toHaveBeenNthCalledWith(2, fresh);
+  });
+
+  it("recovers from the SDK transport-lost envelope too", async () => {
+    const stale = makeSession("stale");
+    const fresh = makeSession("fresh");
+    const pool = makePool(fresh);
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(transportLostError())
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      requestWithSessionRecovery({ ...baseOpts(pool, stale), attempt }),
+    ).resolves.toBe("ok");
+    expect(pool.invalidateServerConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows non-recoverable errors without invalidating the pool", async () => {
+    const session = makeSession("stale");
+    const pool = makePool(undefined);
+    const boom = new Error("schema validation failed");
+    const attempt = vi.fn().mockRejectedValue(boom);
+
+    await expect(
+      requestWithSessionRecovery({ ...baseOpts(pool, session), attempt }),
+    ).rejects.toBe(boom);
+    expect(pool.invalidateServerConnection).not.toHaveBeenCalled();
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a re-init error when no fresh session can be established", async () => {
+    const session = makeSession("stale");
+    const pool = makePool(undefined);
+    const attempt = vi.fn().mockRejectedValue(sessionLostError());
+
+    await expect(
+      requestWithSessionRecovery({ ...baseOpts(pool, session), attempt }),
+    ).rejects.toThrow(
+      /Failed to re-initialize session for server server-1 .* tools\/list/,
+    );
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates the retry's failure when the fresh session also fails", async () => {
+    const stale = makeSession("stale");
+    const fresh = makeSession("fresh");
+    const pool = makePool(fresh);
+    const secondFailure = new Error("backend exploded after reconnect");
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(sessionLostError())
+      .mockRejectedValueOnce(secondFailure);
+
+    await expect(
+      requestWithSessionRecovery({ ...baseOpts(pool, stale), attempt }),
+    ).rejects.toBe(secondFailure);
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/lib/metamcp/list-handler-recovery.ts
+++ b/apps/backend/src/lib/metamcp/list-handler-recovery.ts
@@ -1,0 +1,99 @@
+import { ServerParameters } from "@repo/zod-types";
+
+import logger from "@/utils/logger";
+
+import { ConnectedClient } from "./client";
+import { isRecoverableBackendError } from "./session-error";
+
+/**
+ * Minimal slice of McpServerPool the recovery wrapper needs. Structural
+ * so tests can drive the wrapper with a fake pool.
+ */
+export interface RecoverySessionPool {
+  invalidateServerConnection(
+    sessionId: string,
+    serverUuid: string,
+  ): Promise<void>;
+  getSession(
+    sessionId: string,
+    serverUuid: string,
+    params: ServerParameters,
+    namespaceUuid?: string,
+  ): Promise<ConnectedClient | undefined>;
+}
+
+export interface RequestWithSessionRecoveryOptions<T> {
+  pool: RecoverySessionPool;
+  sessionId: string;
+  serverUuid: string;
+  params: ServerParameters;
+  namespaceUuid?: string;
+  /** Operation label for log lines, e.g. "tools/list". */
+  operation: string;
+  /** Human-readable server name for log lines. */
+  serverName: string;
+  /** The (possibly stale) pooled session the caller already holds. */
+  session: ConnectedClient;
+  /**
+   * The actual backend request(s). Re-invoked exactly once on a fresh
+   * session if the first invocation fails with a recoverable backend
+   * error (session-lost / transport-lost envelope).
+   */
+  attempt: (session: ConnectedClient) => Promise<T>;
+  /**
+   * Called when recovery swapped in a fresh session — lets the caller
+   * repoint tool/prompt/resource maps to the new client.
+   */
+  onFreshSession?: (session: ConnectedClient) => void;
+}
+
+/**
+ * Invalidate-and-retry-once recovery cascade for the per-server fetch
+ * inside the aggregate list handlers (tools/list, prompts/list,
+ * resources/list, resources/templates/list).
+ *
+ * The aggregate list handlers previously logged-and-continued in their
+ * catch blocks, so a dead pooled session (e.g. after a restart of the
+ * backend container) made the namespace return a "successful" 0-tool
+ * response on every request, forever — the swallowed error meant the
+ * zombie connection was never invalidated.
+ *
+ * Throws when the error is non-recoverable, when no fresh session could
+ * be established, or when the retry on the fresh session fails — the
+ * caller decides whether that excludes one server from an aggregate
+ * response (and tracks it as degraded) or fails the request.
+ */
+export async function requestWithSessionRecovery<T>(
+  opts: RequestWithSessionRecoveryOptions<T>,
+): Promise<T> {
+  try {
+    return await opts.attempt(opts.session);
+  } catch (error) {
+    if (!isRecoverableBackendError(error)) {
+      throw error;
+    }
+
+    logger.warn(
+      `Backend connection lost for server ${opts.serverUuid} (${opts.serverName}) on ${opts.operation}; invalidating pool and retrying once. (envelope: ${
+        error instanceof Error ? error.message : String(error)
+      })`,
+    );
+
+    await opts.pool.invalidateServerConnection(opts.sessionId, opts.serverUuid);
+
+    const fresh = await opts.pool.getSession(
+      opts.sessionId,
+      opts.serverUuid,
+      opts.params,
+      opts.namespaceUuid,
+    );
+    if (!fresh) {
+      throw new Error(
+        `Failed to re-initialize session for server ${opts.serverUuid} after backend session loss during ${opts.operation}`,
+      );
+    }
+
+    opts.onFreshSession?.(fresh);
+    return await opts.attempt(fresh);
+  }
+}

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -438,6 +438,91 @@ export class McpServerPool {
   }
 
   /**
+   * Drop the pooled backend connection(s) for a given serverUuid.
+   *
+   * Used when a backend MCP server reports our Mcp-Session-Id is unknown
+   * or our transport is dead (e.g. after the backend container restarts and
+   * loses its in-memory session registry, or a Watchtower swap kills the
+   * socket). No replacement is created here; the next `getSession` call
+   * establishes a fresh connection (and therefore a fresh backend session)
+   * on demand.
+   *
+   * The invalidation CASCADES across every session's slot for the affected
+   * serverUuid, not just the triggering session's slot, plus the idle slot.
+   * When a backend container restarts, EVERY cached ConnectedClient for that
+   * serverUuid is dead — stale clients left in sibling sessions' slots for
+   * the same backend would defeat a single-slot invalidation: a later
+   * `getSession` for one of those siblings would hand back a dead client and
+   * the retry would fail with the same envelope that triggered recovery. So
+   * we drop them all.
+   */
+  async invalidateServerConnection(
+    sessionId: string,
+    serverUuid: string,
+  ): Promise<void> {
+    // Collect every doomed ConnectedClient across all active sessions plus
+    // the idle slot, dropping the map entries as we go.
+    const cleanupPromises: Promise<void>[] = [];
+
+    for (const [sid, sessionServers] of Object.entries(this.activeSessions)) {
+      const cachedClient = sessionServers[serverUuid];
+      if (!cachedClient) {
+        continue;
+      }
+      // Each cleanup is wrapped so one failure can't strand the rest — we
+      // WANT every stale slot dropped from the map regardless.
+      cleanupPromises.push(
+        (async () => {
+          try {
+            await cachedClient.cleanup();
+          } catch (error) {
+            logger.error(
+              `Error cleaning up invalidated active session ${sid}/${serverUuid}:`,
+              error,
+            );
+          }
+        })(),
+      );
+      delete sessionServers[serverUuid];
+      this.sessionToServers[sid]?.delete(serverUuid);
+    }
+
+    const idleClient = this.idleSessions[serverUuid];
+    if (idleClient) {
+      cleanupPromises.push(
+        (async () => {
+          try {
+            await idleClient.cleanup();
+          } catch (error) {
+            logger.error(
+              `Error cleaning up invalidated idle session for ${serverUuid}:`,
+              error,
+            );
+          }
+        })(),
+      );
+      delete this.idleSessions[serverUuid];
+    }
+
+    // Drop the in-flight idle-creation guard so the recovery's getSession
+    // call isn't blocked from spawning a fresh connection.
+    this.creatingIdleSessions.delete(serverUuid);
+
+    await Promise.all(cleanupPromises);
+
+    if (cleanupPromises.length > 0) {
+      logger.warn(
+        `Invalidated ${cleanupPromises.length} pooled backend connection(s) for server ${serverUuid} ` +
+          `(triggered by session ${sessionId}; cascaded across every active + idle slot for this serverUuid)`,
+      );
+    } else {
+      logger.warn(
+        `Invalidated pooled backend connection for server ${serverUuid} (session ${sessionId}) — no clients were cached`,
+      );
+    }
+  }
+
+  /**
    * Invalidate and refresh idle session for a specific server
    * This should be called when a server's parameters (command, args, etc.) change
    */

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -27,6 +27,7 @@ import { toolsImplementations } from "../../trpc/tools.impl";
 import { configService } from "../config.service";
 import { ConnectedClient } from "./client";
 import { getMcpServers } from "./fetch-metamcp";
+import { requestWithSessionRecovery } from "./list-handler-recovery";
 import { mcpServerPool } from "./mcp-server-pool";
 import {
   createFilterCallToolMiddleware,
@@ -157,6 +158,12 @@ export const createServer = async (
     );
     const allTools: Tool[] = [];
 
+    // Servers that should have contributed tools but failed even after the
+    // recovery retry (or had no session at all). Drives the degraded-response
+    // tripwire after the fan-out — a swallowed failure returns a "successful"
+    // 0-tool namespace and nobody notices until a manual restart.
+    const failedServers: string[] = [];
+
     // Track visited servers to detect circular references - reset on each call
     const visitedServers = new Set<string>();
 
@@ -186,6 +193,14 @@ export const createServer = async (
         );
         if (!session) {
           console.log(`[DEBUG-TOOLS] ❌ No session for: ${params.name}`);
+          // No pooled session and the pool couldn't create one — server is
+          // ERROR-gated, connection-capped, or unreachable. Error level: this
+          // server is silently missing from the namespace's tool surface
+          // until the pool recovers.
+          logger.error(
+            `tools/list: no session available for server ${params.name || mcpServerUuid} — excluded from namespace response (error state, connection cap, or backend unreachable)`,
+          );
+          failedServers.push(params.name || mcpServerUuid);
           return;
         }
 
@@ -217,32 +232,58 @@ export const createServer = async (
           params.name || session.client.getServerVersion()?.name || "";
 
         try {
-          // Paginated tool discovery - load all pages automatically
-          const allServerTools: Tool[] = [];
-          let cursor: string | undefined = undefined;
-          let hasMore = true;
           const toolFetchStart = performance.now();
 
-          while (hasMore) {
-            const result: z.infer<typeof ListToolsResultSchema> =
-              await session.client.request(
-                {
-                  method: "tools/list",
-                  params: {
-                    cursor: cursor,
-                    _meta: request.params?._meta,
-                  },
-                },
-                ListToolsResultSchema,
-              );
+          // Paginated tool discovery - load all pages automatically
+          const fetchAllToolPages = async (
+            active: ConnectedClient,
+          ): Promise<Tool[]> => {
+            const pages: Tool[] = [];
+            let cursor: string | undefined = undefined;
+            let hasMore = true;
 
-            if (result.tools && result.tools.length > 0) {
-              allServerTools.push(...result.tools);
+            while (hasMore) {
+              const result: z.infer<typeof ListToolsResultSchema> =
+                await active.client.request(
+                  {
+                    method: "tools/list",
+                    params: {
+                      cursor: cursor,
+                      _meta: request.params?._meta,
+                    },
+                  },
+                  ListToolsResultSchema,
+                );
+
+              if (result.tools && result.tools.length > 0) {
+                pages.push(...result.tools);
+              }
+
+              cursor = result.nextCursor;
+              hasMore = !!result.nextCursor;
             }
 
-            cursor = result.nextCursor;
-            hasMore = !!result.nextCursor;
-          }
+            return pages;
+          };
+
+          // Invalidate-and-retry-once on session-lost / transport-lost.
+          // Without it a dead pooled session is never evicted from here and
+          // the namespace serves 0 tools as "success" until a manual restart.
+          let activeSession = session;
+          const allServerTools = await requestWithSessionRecovery({
+            pool: mcpServerPool,
+            sessionId: context.sessionId,
+            serverUuid: mcpServerUuid,
+            params,
+            namespaceUuid,
+            operation: "tools/list",
+            serverName,
+            session,
+            attempt: fetchAllToolPages,
+            onFreshSession: (fresh) => {
+              activeSession = fresh;
+            },
+          });
 
           console.log(
             `[DEBUG-TOOLS] ⏱️  Fetched ${allServerTools.length} tools from ${serverName} in ${(performance.now() - toolFetchStart).toFixed(2)}ms`,
@@ -291,7 +332,7 @@ export const createServer = async (
           // Use original tools for client response (middleware will be applied later)
           const toolsWithSource = allServerTools.map((tool) => {
             const toolName = `${sanitizeName(serverName)}__${tool.name}`;
-            toolToClient[toolName] = session;
+            toolToClient[toolName] = activeSession;
             toolToServerUuid[toolName] = mcpServerUuid;
 
             return {
@@ -304,6 +345,7 @@ export const createServer = async (
           allTools.push(...toolsWithSource);
         } catch (error) {
           logger.error(`Error fetching tools from: ${serverName}`, error);
+          failedServers.push(serverName || mcpServerUuid);
         }
       }),
     );
@@ -312,6 +354,16 @@ export const createServer = async (
     console.log(
       `[DEBUG-TOOLS] ✅ tools/list completed in ${totalTime.toFixed(2)}ms, returning ${allTools.length} tools`,
     );
+
+    // Degraded-response tripwire: a server that should have contributed tools
+    // failed even after the recovery retry (or had no session). The response
+    // is still returned (partial truth beats a hard error for the surviving
+    // servers) but the failure must be loud enough for log-based monitoring.
+    if (failedServers.length > 0) {
+      logger.error(
+        `tools/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length}/${allServerEntries.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allTools.length} tools`,
+      );
+    }
 
     return { tools: allTools };
   };
@@ -545,6 +597,7 @@ export const createServer = async (
       includeInactiveServers,
     );
     const allPrompts: z.infer<typeof ListPromptsResultSchema>["prompts"] = [];
+    const failedServers: string[] = [];
 
     // Track visited servers to detect circular references - reset on each call
     const visitedServers = new Set<string>();
@@ -582,7 +635,13 @@ export const createServer = async (
           params,
           namespaceUuid,
         );
-        if (!session) return;
+        if (!session) {
+          logger.error(
+            `prompts/list: no session available for server ${params.name || uuid} — excluded from namespace response (error state, connection cap, or backend unreachable)`,
+          );
+          failedServers.push(params.name || uuid);
+          return;
+        }
 
         // Now check for self-referencing using the actual MCP server name
         const serverVersion = session.client.getServerVersion();
@@ -603,21 +662,36 @@ export const createServer = async (
         const serverName =
           params.name || session.client.getServerVersion()?.name || "";
         try {
-          const result = await session.client.request(
-            {
-              method: "prompts/list",
-              params: {
-                cursor: request.params?.cursor,
-                _meta: request.params?._meta,
-              },
+          let activeSession = session;
+          const result = await requestWithSessionRecovery({
+            pool: mcpServerPool,
+            sessionId,
+            serverUuid: uuid,
+            params,
+            namespaceUuid,
+            operation: "prompts/list",
+            serverName,
+            session,
+            attempt: (active) =>
+              active.client.request(
+                {
+                  method: "prompts/list",
+                  params: {
+                    cursor: request.params?.cursor,
+                    _meta: request.params?._meta,
+                  },
+                },
+                ListPromptsResultSchema,
+              ),
+            onFreshSession: (fresh) => {
+              activeSession = fresh;
             },
-            ListPromptsResultSchema,
-          );
+          });
 
           if (result.prompts) {
             const promptsWithSource = result.prompts.map((prompt) => {
               const promptName = `${sanitizeName(serverName)}__${prompt.name}`;
-              promptToClient[promptName] = session;
+              promptToClient[promptName] = activeSession;
               return {
                 ...prompt,
                 name: promptName,
@@ -628,9 +702,16 @@ export const createServer = async (
           }
         } catch (error) {
           logger.error(`Error fetching prompts from: ${serverName}`, error);
+          failedServers.push(serverName || uuid);
         }
       }),
     );
+
+    if (failedServers.length > 0) {
+      logger.error(
+        `prompts/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allPrompts.length} prompts`,
+      );
+    }
 
     return {
       prompts: allPrompts,
@@ -646,6 +727,7 @@ export const createServer = async (
     );
     const allResources: z.infer<typeof ListResourcesResultSchema>["resources"] =
       [];
+    const failedServers: string[] = [];
 
     // Track visited servers to detect circular references - reset on each call
     const visitedServers = new Set<string>();
@@ -683,7 +765,13 @@ export const createServer = async (
           params,
           namespaceUuid,
         );
-        if (!session) return;
+        if (!session) {
+          logger.error(
+            `resources/list: no session available for server ${params.name || uuid} — excluded from namespace response (error state, connection cap, or backend unreachable)`,
+          );
+          failedServers.push(params.name || uuid);
+          return;
+        }
 
         // Now check for self-referencing using the actual MCP server name
         const serverVersion = session.client.getServerVersion();
@@ -704,20 +792,35 @@ export const createServer = async (
         const serverName =
           params.name || session.client.getServerVersion()?.name || "";
         try {
-          const result = await session.client.request(
-            {
-              method: "resources/list",
-              params: {
-                cursor: request.params?.cursor,
-                _meta: request.params?._meta,
-              },
+          let activeSession = session;
+          const result = await requestWithSessionRecovery({
+            pool: mcpServerPool,
+            sessionId,
+            serverUuid: uuid,
+            params,
+            namespaceUuid,
+            operation: "resources/list",
+            serverName,
+            session,
+            attempt: (active) =>
+              active.client.request(
+                {
+                  method: "resources/list",
+                  params: {
+                    cursor: request.params?.cursor,
+                    _meta: request.params?._meta,
+                  },
+                },
+                ListResourcesResultSchema,
+              ),
+            onFreshSession: (fresh) => {
+              activeSession = fresh;
             },
-            ListResourcesResultSchema,
-          );
+          });
 
           if (result.resources) {
             const resourcesWithSource = result.resources.map((resource) => {
-              resourceToClient[resource.uri] = session;
+              resourceToClient[resource.uri] = activeSession;
               return {
                 ...resource,
                 name: resource.name || "",
@@ -727,9 +830,16 @@ export const createServer = async (
           }
         } catch (error) {
           logger.error(`Error fetching resources from: ${serverName}`, error);
+          failedServers.push(serverName || uuid);
         }
       }),
     );
+
+    if (failedServers.length > 0) {
+      logger.error(
+        `resources/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allResources.length} resources`,
+      );
+    }
 
     return {
       resources: allResources,
@@ -777,6 +887,7 @@ export const createServer = async (
         includeInactiveServers,
       );
       const allTemplates: ResourceTemplate[] = [];
+      const failedServers: string[] = [];
 
       // Track visited servers to detect circular references - reset on each call
       const visitedServers = new Set<string>();
@@ -814,7 +925,13 @@ export const createServer = async (
             params,
             namespaceUuid,
           );
-          if (!session) return;
+          if (!session) {
+            logger.error(
+              `resources/templates/list: no session available for server ${params.name || uuid} — excluded from namespace response (error state, connection cap, or backend unreachable)`,
+            );
+            failedServers.push(params.name || uuid);
+            return;
+          }
 
           // Now check for self-referencing using the actual MCP server name
           const serverVersion = session.client.getServerVersion();
@@ -835,16 +952,30 @@ export const createServer = async (
             params.name || session.client.getServerVersion()?.name || "";
 
           try {
-            const result = await session.client.request(
-              {
-                method: "resources/templates/list",
-                params: {
-                  cursor: request.params?.cursor,
-                  _meta: request.params?._meta,
-                },
-              },
-              ListResourceTemplatesResultSchema,
-            );
+            // No per-client map to repoint here (templates aren't keyed to a
+            // client), so onFreshSession is omitted — the recovery still
+            // invalidates + retries on the fresh session.
+            const result = await requestWithSessionRecovery({
+              pool: mcpServerPool,
+              sessionId,
+              serverUuid: uuid,
+              params,
+              namespaceUuid,
+              operation: "resources/templates/list",
+              serverName,
+              session,
+              attempt: (active) =>
+                active.client.request(
+                  {
+                    method: "resources/templates/list",
+                    params: {
+                      cursor: request.params?.cursor,
+                      _meta: request.params?._meta,
+                    },
+                  },
+                  ListResourceTemplatesResultSchema,
+                ),
+            });
 
             if (result.resourceTemplates) {
               const templatesWithSource = result.resourceTemplates.map(
@@ -860,10 +991,17 @@ export const createServer = async (
               `Error fetching resource templates from: ${serverName}`,
               error,
             );
+            failedServers.push(serverName || uuid);
             return;
           }
         }),
       );
+
+      if (failedServers.length > 0) {
+        logger.error(
+          `resources/templates/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allTemplates.length} templates`,
+        );
+      }
 
       return {
         resourceTemplates: allTemplates,

--- a/apps/backend/src/lib/metamcp/session-error.test.ts
+++ b/apps/backend/src/lib/metamcp/session-error.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isBackendSessionLostError,
+  isBackendTransportLostError,
+  isRecoverableBackendError,
+} from "./session-error";
+
+describe("isBackendSessionLostError", () => {
+  it("matches the HTTP 404 + JSON-RPC -32600 envelope the SDK produces", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("matches the HTTP 404 + JSON-RPC -32001 variant some servers return", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"error":{"code":-32001,"message":"Session not found"},"id":"","jsonrpc":"2.0"}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("does not match unrelated 404s", () => {
+    const error = new Error("Error POSTing to endpoint (HTTP 404): Not Found");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("does not match transport disconnects (transport-lost detector handles those)", () => {
+    const error = new Error("Not connected");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("returns false for null / undefined", () => {
+    expect(isBackendSessionLostError(undefined)).toBe(false);
+    expect(isBackendSessionLostError(null)).toBe(false);
+  });
+
+  it("returns false for unrelated strings", () => {
+    expect(isBackendSessionLostError("Session not found")).toBe(false);
+    expect(isBackendSessionLostError("HTTP 404")).toBe(false);
+    expect(isBackendSessionLostError("random text")).toBe(false);
+  });
+
+  it("matches a string throwable carrying the full envelope", () => {
+    const message =
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}';
+    expect(isBackendSessionLostError(message)).toBe(true);
+  });
+
+  it("matches when the session-lost error is wrapped via .cause", () => {
+    const inner = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    const outer = new Error("Failed to dispatch tool call", { cause: inner });
+    expect(isBackendSessionLostError(outer)).toBe(true);
+  });
+
+  it("matches when wrapped two layers deep via .cause", () => {
+    const innermost = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"}}',
+    );
+    const mid = new Error("Transport rejection", { cause: innermost });
+    const outer = new Error("Outer wrap", { cause: mid });
+    expect(isBackendSessionLostError(outer)).toBe(true);
+  });
+
+  it("matches a JSON-RPC error envelope passed as a plain object", () => {
+    // Some rejection paths surface the parsed RPC error envelope directly
+    // rather than the SDK's wrapped Error. The detector inspects the
+    // structured payload as well as the rendered message.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32600, message: "Session not found" },
+    };
+    expect(isBackendSessionLostError(envelope)).toBe(true);
+  });
+
+  it("matches an Error whose .code carries -32001 even when the message is sparse", () => {
+    const error = Object.assign(new Error("Session not found"), {
+      code: -32001,
+    });
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("falls back to String(error) for objects with only toString()", () => {
+    class CustomThrowable {
+      toString() {
+        return 'Error POSTing to endpoint (HTTP 404): {"error":{"code":-32600,"message":"Session not found"}}';
+      }
+    }
+    expect(isBackendSessionLostError(new CustomThrowable())).toBe(true);
+  });
+
+  it("does not match objects with unrelated -32600 contexts", () => {
+    // -32600 alone (without 'Session not found') is the JSON-RPC "Invalid
+    // Request" code and means many things. Don't false-positive on it.
+    const error = new Error("MCP error -32600: Invalid Request");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("handles circular cause chains without infinite-looping", () => {
+    const a = new Error("Wrapper a") as Error & { cause?: unknown };
+    const b = new Error("Wrapper b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isBackendSessionLostError(a)).toBe(false);
+  });
+});
+
+describe("isBackendTransportLostError", () => {
+  it("matches the bare SDK 'Not connected' Error", () => {
+    // Protocol.request() in the MCP TS SDK rejects with exactly this
+    // message when the underlying transport has been torn down.
+    const error = new Error("Not connected");
+    expect(isBackendTransportLostError(error)).toBe(true);
+  });
+
+  it("matches a 'Not connected' string throwable", () => {
+    expect(isBackendTransportLostError("Not connected")).toBe(true);
+  });
+
+  it("matches the consumer-side -32603 envelope MetaMCP returns to Claude.ai / n8n", () => {
+    // Production observation 2026-05-14: consumer-side connectors see
+    // the tRPC bridge's wrapped envelope rather than the raw SDK Error.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32603, message: "Not connected" },
+    };
+    expect(isBackendTransportLostError(envelope)).toBe(true);
+  });
+
+  it("matches when the transport-lost error is wrapped via .cause", () => {
+    const inner = new Error("Not connected");
+    const outer = new Error("Tool dispatch rejected", { cause: inner });
+    expect(isBackendTransportLostError(outer)).toBe(true);
+  });
+
+  it("matches when wrapped two layers deep via .cause", () => {
+    const innermost = new Error("Not connected");
+    const mid = new Error("Transport adapter rejection", { cause: innermost });
+    const outer = new Error("Outer wrap", { cause: mid });
+    expect(isBackendTransportLostError(outer)).toBe(true);
+  });
+
+  it("matches Error with .code -32603 + 'Not connected' message", () => {
+    const error = Object.assign(new Error("Not connected"), { code: -32603 });
+    expect(isBackendTransportLostError(error)).toBe(true);
+  });
+
+  it("does not false-positive on unrelated -32603 'Internal error' envelopes", () => {
+    // Bare -32603 is JSON-RPC "Internal error" and covers many flows.
+    // Detector only fires when paired with the 'Not connected' marker.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "x",
+      error: { code: -32603, message: "Internal error" },
+    };
+    expect(isBackendTransportLostError(envelope)).toBe(false);
+  });
+
+  it("does not match session-not-found envelopes (those go to the session-lost detector)", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isBackendTransportLostError(error)).toBe(false);
+  });
+
+  it("returns false for null / undefined / unrelated strings", () => {
+    expect(isBackendTransportLostError(undefined)).toBe(false);
+    expect(isBackendTransportLostError(null)).toBe(false);
+    expect(isBackendTransportLostError("just some text")).toBe(false);
+    expect(isBackendTransportLostError(new Error("Timeout"))).toBe(false);
+  });
+
+  it("handles circular .cause chains without infinite-looping", () => {
+    const a = new Error("Wrapper a") as Error & { cause?: unknown };
+    const b = new Error("Wrapper b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isBackendTransportLostError(a)).toBe(false);
+  });
+
+  it("falls back to String(error) for custom throwables", () => {
+    class CustomTransportError {
+      toString() {
+        return "Not connected";
+      }
+    }
+    expect(isBackendTransportLostError(new CustomTransportError())).toBe(true);
+  });
+});
+
+describe("isRecoverableBackendError", () => {
+  it("fires on session-not-found envelopes", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isRecoverableBackendError(error)).toBe(true);
+  });
+
+  it("fires on transport-disconnect envelopes", () => {
+    expect(isRecoverableBackendError(new Error("Not connected"))).toBe(true);
+  });
+
+  it("fires on the consumer-side -32603 envelope (2026-05-14 production case)", () => {
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32603, message: "Not connected" },
+    };
+    expect(isRecoverableBackendError(envelope)).toBe(true);
+  });
+
+  it("does not false-positive on unrelated errors", () => {
+    expect(isRecoverableBackendError(new Error("Timeout"))).toBe(false);
+    expect(isRecoverableBackendError(undefined)).toBe(false);
+    expect(
+      isRecoverableBackendError({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal error" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/lib/metamcp/session-error.ts
+++ b/apps/backend/src/lib/metamcp/session-error.ts
@@ -1,0 +1,290 @@
+/**
+ * Detect errors that indicate the backend MCP server's session registry no
+ * longer knows our Mcp-Session-Id. Per the MCP Streamable HTTP spec, the
+ * backend SHOULD respond with HTTP 404 when it cannot find the session; most
+ * SDKs also surface a JSON-RPC error body with code -32001 or -32600 and
+ * message "Session not found".
+ *
+ * The MCP TypeScript SDK's StreamableHTTPClientTransport wraps this as a
+ * generic Error whose message embeds the HTTP status and raw JSON-RPC body,
+ * so we match on substrings. Example:
+ *
+ *   Error POSTing to endpoint (HTTP 404):
+ *   {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}
+ *
+ * Production observation 2026-05-08: in some flows the SDK error reaches us
+ * wrapped (e.g. via `.cause` from a higher-layer handler, or stringified
+ * after passing through a non-Error rejection). The simple
+ * `error.message.includes(...)` check missed all 138 events emitted between
+ * a backend container restart and a manual MetaMCP restart, even though the
+ * rendered string clearly contained all three matched substrings. To prevent
+ * that gap from re-opening on the next backend deploy, this detector now:
+ *
+ *   1. Walks the `.cause` chain on Error inputs (max depth 8).
+ *   2. Falls back to `String(error)` for non-Error throwables (some SDK
+ *      paths reject with plain objects, McpError wrappers, or strings).
+ *   3. Inspects a numeric/string `.code` field on object inputs (some
+ *      RPC layers strip the message but preserve the code).
+ *
+ * When this fires, the cached backend connection is dead: MetaMCP must drop
+ * it, send a new `initialize`, and replay the failed request. The MCP spec
+ * states the client MUST start a new session in response to HTTP 404, so
+ * this is the normative recovery path, not a workaround.
+ */
+
+const SESSION_NOT_FOUND = "Session not found";
+const HTTP_404 = "HTTP 404";
+const RPC_CODE_PATTERNS = ["-32001", "-32600"];
+const MAX_CAUSE_DEPTH = 8;
+
+// Transport-disconnect signal raised by the MCP TypeScript SDK's Protocol
+// class when a request is dispatched on a transport that has already been
+// torn down. Produced verbatim ("Not connected") whenever the cached
+// ConnectedClient's underlying StreamableHTTPClientTransport has been
+// closed — either because the backend MCP container restarted (Watchtower
+// image pull, manual `docker restart`, OOM kill) or because the SDK's
+// session manager half-closed the stream after an idle / error condition.
+//
+// Distinct from "Session not found": the session-not-found path means the
+// backend rejected the request because its session registry doesn't know
+// our Mcp-Session-Id (recoverable by sending a new `initialize`). The
+// "Not connected" path means our local transport has no live stream to
+// send anything on (recoverable by invalidating the pool entry, opening
+// a fresh transport, and re-initializing). Both end up at the same
+// recovery action — invalidate + reconnect + retry — but the error
+// envelopes are textually disjoint, so they need separate detectors.
+const NOT_CONNECTED = "Not connected";
+// JSON-RPC code -32603 = "Internal error". MetaMCP's tRPC bridge wraps
+// the SDK-thrown "Not connected" rejection into this envelope before it
+// reaches the consumer (Claude.ai connector, n8n httpRequest node, etc.).
+// Production observation 2026-05-14: consumer-side connectors see
+// `-32603 "Not connected"` rather than the raw SDK Error, and the
+// session-lost detector misses it. Pair the code with the
+// "Not connected" message so we don't false-positive on every -32603
+// from unrelated internal-error paths.
+const RPC_CODE_TRANSPORT_LOST = "-32603";
+
+function stringMatchesSessionLost(value: string): boolean {
+  const mentionsSessionNotFound = value.includes(SESSION_NOT_FOUND);
+  const mentionsHttp404 = value.includes(HTTP_404);
+  const mentionsSessionErrorCode = RPC_CODE_PATTERNS.some((code) =>
+    value.includes(code),
+  );
+  return (
+    mentionsSessionNotFound && (mentionsHttp404 || mentionsSessionErrorCode)
+  );
+}
+
+function objectHasSessionLostCode(candidate: unknown): boolean {
+  if (typeof candidate !== "object" || candidate === null) {
+    return false;
+  }
+  const code = (candidate as { code?: unknown }).code;
+  if (typeof code === "number") {
+    return code === -32001 || code === -32600;
+  }
+  if (typeof code === "string") {
+    return code === "-32001" || code === "-32600";
+  }
+  return false;
+}
+
+function stringMatchesTransportLost(value: string): boolean {
+  // The "Not connected" substring is the load-bearing marker; the
+  // -32603 code is only a confirming signal when present in a JSON-RPC
+  // envelope. A bare "Not connected" message from the SDK is sufficient.
+  return value.includes(NOT_CONNECTED);
+}
+
+function objectHasTransportLostCode(candidate: unknown): boolean {
+  // Only match -32603 when the rendered/structured object also carries
+  // the "Not connected" marker — bare -32603 is JSON-RPC "Internal
+  // error" and covers many unrelated failure modes.
+  if (typeof candidate !== "object" || candidate === null) {
+    return false;
+  }
+  const obj = candidate as { code?: unknown; message?: unknown };
+  const code = obj.code;
+  const isTransportCode =
+    code === -32603 ||
+    code === "-32603" ||
+    (typeof code === "string" && code.includes(RPC_CODE_TRANSPORT_LOST));
+  if (!isTransportCode) {
+    return false;
+  }
+  if (
+    typeof obj.message === "string" &&
+    stringMatchesTransportLost(obj.message)
+  ) {
+    return true;
+  }
+  try {
+    return stringMatchesTransportLost(JSON.stringify(candidate));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect errors that indicate the cached backend client's transport is dead.
+ *
+ * Sibling of {@link isBackendSessionLostError}. The session-lost detector
+ * matches the backend's "I don't know your Mcp-Session-Id" response (HTTP
+ * 404 + JSON-RPC -32001/-32600 + "Session not found"). The transport-lost
+ * detector matches the SDK's local "I have no live stream to send on"
+ * rejection, surfaced as a bare `"Not connected"` Error from
+ * `Protocol.request()` and also as a `-32603 "Not connected"` JSON-RPC
+ * envelope on the consumer-facing side.
+ *
+ * When this fires, the recovery action is identical to the session-lost
+ * path: invalidate the pooled `ConnectedClient`, open a fresh transport,
+ * re-initialize, and replay the request once. The two detectors are kept
+ * separate (rather than collapsed into one OR-of-substrings function) so
+ * each has a tight predicate that doesn't false-positive on the much
+ * larger noise floor of unrelated -32603 / 404 errors.
+ *
+ * Production observation 2026-05-14: rapid-deploy cadence on the autotask
+ * MCP backend (Watchtower pulls + container restarts within a 5-min
+ * window) produced disconnect windows where the consumer-side connector
+ * saw `-32603 "Not connected"` on every call. The session-lost detector
+ * missed all of these; the recovery path in `metamcp-proxy.ts` never
+ * fired. Operator quote (2026-05-14): "It's not acceptable for having
+ * MCP servers down or needing reboots after small change applications."
+ * This detector + the matching recovery wiring in `metamcp-proxy.ts`
+ * close that gap.
+ */
+export function isBackendTransportLostError(error: unknown): boolean {
+  if (error == null) {
+    return false;
+  }
+
+  if (typeof error === "string") {
+    return stringMatchesTransportLost(error);
+  }
+
+  let current: unknown = error;
+  let depth = 0;
+  const seen = new Set<unknown>();
+  while (current != null && depth < MAX_CAUSE_DEPTH) {
+    if (seen.has(current)) {
+      // Circular .cause chain — bail out.
+      break;
+    }
+    seen.add(current);
+
+    if (current instanceof Error) {
+      if (current.message && stringMatchesTransportLost(current.message)) {
+        return true;
+      }
+      if (objectHasTransportLostCode(current)) {
+        return true;
+      }
+      current = (current as { cause?: unknown }).cause;
+      depth += 1;
+      continue;
+    }
+
+    if (typeof current === "object") {
+      const obj = current as { message?: unknown };
+      if (
+        typeof obj.message === "string" &&
+        stringMatchesTransportLost(obj.message)
+      ) {
+        return true;
+      }
+      if (objectHasTransportLostCode(current)) {
+        return true;
+      }
+      try {
+        const rendered = JSON.stringify(current);
+        if (stringMatchesTransportLost(rendered)) {
+          return true;
+        }
+      } catch {
+        // Non-serializable; fall through.
+      }
+      break;
+    }
+    break;
+  }
+
+  try {
+    return stringMatchesTransportLost(String(error));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Convenience predicate — either the session-lost OR transport-lost
+ * detector fires. Tool-call and dynamic-find recovery paths in
+ * `metamcp-proxy.ts` use this so they engage the same invalidate +
+ * reconnect + retry sequence regardless of which envelope the failure
+ * arrived in.
+ */
+export function isRecoverableBackendError(error: unknown): boolean {
+  return isBackendSessionLostError(error) || isBackendTransportLostError(error);
+}
+
+export function isBackendSessionLostError(error: unknown): boolean {
+  if (error == null) {
+    return false;
+  }
+
+  // String inputs (some rejection paths surface a bare string).
+  if (typeof error === "string") {
+    return stringMatchesSessionLost(error);
+  }
+
+  // Walk Error.cause chain — match any link in the chain.
+  let current: unknown = error;
+  let depth = 0;
+  while (current != null && depth < MAX_CAUSE_DEPTH) {
+    if (current instanceof Error) {
+      if (current.message && stringMatchesSessionLost(current.message)) {
+        return true;
+      }
+      if (objectHasSessionLostCode(current)) {
+        return true;
+      }
+      current = (current as { cause?: unknown }).cause;
+      depth += 1;
+      continue;
+    }
+    if (typeof current === "object") {
+      // Plain object (e.g. JSON-RPC error envelope): inspect message + code.
+      const obj = current as { message?: unknown; code?: unknown };
+      if (
+        typeof obj.message === "string" &&
+        stringMatchesSessionLost(obj.message)
+      ) {
+        return true;
+      }
+      if (objectHasSessionLostCode(obj)) {
+        return true;
+      }
+      // Last-ditch: render the whole object and substring-match. Catches
+      // shapes like `{ jsonrpc, id, error: { code, message } }` where the
+      // session-not-found markers live one level deep.
+      try {
+        const rendered = JSON.stringify(current);
+        if (stringMatchesSessionLost(rendered)) {
+          return true;
+        }
+      } catch {
+        // Circular structure or non-serializable; ignore.
+      }
+      break;
+    }
+    break;
+  }
+
+  // Final fallback: stringify the original input. Covers throwables that
+  // implement only `toString()` (e.g. some legacy transports emit a
+  // class with a meaningful String(...) representation but no message).
+  try {
+    return stringMatchesSessionLost(String(error));
+  } catch {
+    return false;
+  }
+}

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,6 +1,16 @@
+import path from "node:path";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirror the tsconfig.json `paths` mapping so unit tests can
+      // import modules that use the `@/` prefix without each test
+      // having to hand-mock every transitive logger / utils import.
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     globals: true,
     environment: "node",


### PR DESCRIPTION
## Problem

The four aggregate list handlers in `metamcp-proxy.ts` — `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list` — log-and-continue in their per-server catch blocks. When a backend MCP server restarts (container redeploy, crash, image update), every pooled `ConnectedClient` to it is dead, the per-server fetch throws, and the handler swallows the error: the dead connection is **never invalidated**, and the namespace returns a *successful* empty/partial response on every subsequent request until MetaMCP itself is restarted.

We run a downstream fork in production (MSP, ~7 backend servers behind one gateway) and hit this as a full namespace outage: 4 of 5 namespaces served 0 tools for ~24h while every backend was healthy, because the pooled sessions died during backend container updates and `tools/list` kept reusing them. `tools/list` is the first call every MCP client makes — this failure mode is invisible to clients (empty success, no error) and to operators (no error-level logs).

## Fix

Three pieces, self-contained:

1. **`McpServerPool.invalidateServerConnection(sessionId, serverUuid)`** — drops every pooled connection for the affected backend: all active sessions' slots (not just the triggering session's — stale clients cached under sibling sessions would defeat a single-slot invalidation) plus the idle slot. Per-client `cleanup()` is individually guarded so one failure can't strand the rest. No replacement is created; the next `getSession` connects fresh on demand.
2. **`requestWithSessionRecovery` helper** (`list-handler-recovery.ts`) — wraps a per-server backend request: on a recoverable backend error (session-lost / transport-lost envelope, detected by `session-error.ts`), invalidate → re-acquire a fresh session → retry exactly once. Non-recoverable errors pass through untouched.
3. **All four aggregate list handlers wired through the helper**, with client-map repointing on recovery (`toolToClient`/`promptToClient`/`resourceToClient`) and a degraded-response tripwire: any server still excluded after recovery produces one error-level `<op> DEGRADED for namespace …` log line, so monitoring can catch what used to be silent.

## Relationship to #293 / #283

This branch includes #293's `session-error.ts` detectors as its first commit (the helper depends on `isRecoverableBackendError`). If #293 merges first, this rebases cleanly; if this merges, #293 can be closed. #283 (session re-init on 404) addresses the `tools/call` side of the same failure family.

## Tests

- 6 new vitest cases on the recovery helper (first-try success, session-lost + transport-lost recovery, non-recoverable passthrough, re-init failure, retry-failure propagation), plus #293's 29 detector cases. 55 tests green.
- `tsc --noEmit`: zero new errors (4 pre-existing on main, byte-identical before/after).
- `vitest.config.ts` gains the `@/` → `./src` alias so tests can import `@/utils/logger` (matches the backend tsconfig path).

Running in production on our fork since 2026-06-11 across ~7 backends; the backend-redeploy-causes-namespace-outage class is gone.