### PR TITLE
Self-heal server error_status on successful reconnect

### DIFF
--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -95,7 +95,9 @@ export const configService = {
     const config = await configRepo.getConfig(
       ConfigKeyEnum.Enum.MCP_MAX_ATTEMPTS,
     );
-    return config?.value ? parseInt(config.value, 10) : 1;
+    // Default to 3: a single transient blip (e.g. a slow cold-cache `uvx`
+    // spawn) shouldn't immediately flag a server as ERROR.
+    return config?.value ? parseInt(config.value, 10) : 3;
   },
 
   async setMcpMaxAttempts(maxAttempts: number): Promise<void> {

--- a/apps/backend/src/lib/metamcp/client.ts
+++ b/apps/backend/src/lib/metamcp/client.ts
@@ -181,16 +181,15 @@ export const connectMetaMcpClient = async (
     let client: Client | undefined;
 
     try {
-      // Check if server is already in error state before attempting connection
-      const isInErrorState = await serverErrorTracker.isServerInErrorState(
+      // Remember whether this server was previously flagged ERROR. We used to
+      // return early here, which turned ERROR into a one-way trapdoor: a server
+      // that had since recovered could never reconnect, so it could never clear
+      // the flag — only a manual UI edit/save would. Instead, attempt the
+      // connection and, on success, clear the flag below. If it genuinely keeps
+      // crashing, the crash tracker re-flags it.
+      const wasInErrorState = await serverErrorTracker.isServerInErrorState(
         serverParams.uuid,
       );
-      if (isInErrorState) {
-        logger.info(
-          `Server ${serverParams.name} (${serverParams.uuid}) is already in ERROR state, skipping connection attempt`,
-        );
-        return undefined;
-      }
 
       // Create fresh client and transport for each attempt
       const result = createMetaMcpClient(serverParams);
@@ -226,6 +225,15 @@ export const connectMetaMcpClient = async (
       }
 
       await client.connect(transport);
+
+      // Connection succeeded — self-heal any prior ERROR state so a recovered
+      // server isn't left flagged red forever.
+      if (wasInErrorState) {
+        logger.info(
+          `Server ${serverParams.name} (${serverParams.uuid}) reconnected successfully; clearing prior ERROR state.`,
+        );
+        await serverErrorTracker.resetServerErrorState(serverParams.uuid);
+      }
 
       return {
         client,

--- a/apps/backend/src/lib/metamcp/server-error-tracker.ts
+++ b/apps/backend/src/lib/metamcp/server-error-tracker.ts
@@ -19,7 +19,7 @@ export class ServerErrorTracker {
   private crashAttempts: Map<string, number> = new Map();
 
   // Default max attempts before marking as ERROR (fallback if config is not available)
-  private readonly fallbackMaxAttempts: number = 1;
+  private readonly fallbackMaxAttempts: number = 3;
 
   // Server-specific max attempts (can be configured per server)
   private serverMaxAttempts: Map<string, number> = new Map();


### PR DESCRIPTION
## Problem

A server flagged `error_status=ERROR` can never recover automatically.

`connectMetaMcpClient` returns early for any server already in the ERROR state (`"… is already in ERROR state, skipping connection attempt"`), so a server that has since recovered is never reconnected and can therefore never clear the flag — only a manual edit/save in the UI does. Combined with `MCP_MAX_ATTEMPTS` defaulting to `1` (a single crash flips a server to ERROR, and crash attempts never decay), one transient blip leaves a healthy server stuck red forever.

This commonly bites STDIO servers launched via `uvx <pkg>@latest`: the first cold-cache spawn after a version bump can be slow enough to be killed before it finishes, permanently tripping the `maxAttempts=1` crash flag.

## Changes

- **`client.ts`** — drop the early-return for ERROR servers in `connectMetaMcpClient`. Instead, remember the prior ERROR state, attempt the connection, and clear the flag on success (self-heal). If a server genuinely keeps crashing, the crash tracker re-flags it.
- **`config.service.ts`** / **`server-error-tracker.ts`** — raise the `MCP_MAX_ATTEMPTS` default and the in-tracker fallback from `1` to `3`, so a single transient blip no longer immediately flags a server as ERROR.

Net diff: 3 files, +20 / −10.

## How to test

1. Configure a STDIO MCP server (e.g. one launched via `uvx <pkg>@latest`).
2. Force it into ERROR (kill its first cold-cache spawn, or temporarily set `MCP_MAX_ATTEMPTS=1` and trigger one crash). The server shows `error_status=ERROR`.
3. With the fix, the next connection attempt for the now-healthy server succeeds and the ERROR flag clears automatically (see the `… reconnected successfully; clearing prior ERROR state.` log line) — no manual UI edit/save required.