### PR TITLE
Persist uv cache across container recreates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update && apt-get install -y curl postgresql-client && apt-get clean
 # Create non-root user with proper home directory
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 --home /home/nextjs nextjs && \
-    mkdir -p /home/nextjs/.cache/node/corepack && \
+    mkdir -p /home/nextjs/.cache/node/corepack /home/nextjs/.cache/uv && \
     chown -R nextjs:nodejs /home/nextjs
 
 # Copy built applications

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,14 @@ services:
       postgres:
         condition: service_healthy
     restart: "no"
+    volumes:
+      # Persist the uv cache across container recreates. Without this, every
+      # `docker compose up -d`/recreate wipes the writable layer and the next
+      # `uvx <pkg>@latest` spawn for each STDIO server cold-installs from
+      # scratch — slow enough to trip the crash detector and stick the server
+      # in error_status=ERROR. The image ships /home/nextjs/.cache/uv owned by
+      # nextjs (uid 1001) so a fresh named volume inherits correct ownership.
+      - uv_cache:/home/nextjs/.cache/uv
     networks:
       - metamcp-network
 
@@ -190,6 +198,8 @@ services:
 
 volumes:
   postgres_data:
+    driver: local
+  uv_cache:
     driver: local
 
 networks:


### PR DESCRIPTION
## Problem

STDIO MCP servers launched via `uvx <pkg>@latest` cold-install their dependencies on first spawn. There is no volume mounted at the uv cache directory, so every `docker compose up -d` / container recreate wipes the writable layer and the next `uvx` spawn for each STDIO server cold-installs from scratch. That install can be slow enough to trip the crash detector and stick the server in `error_status=ERROR`.

## Changes

- **`Dockerfile`** — create `/home/nextjs/.cache/uv` at build time, owned by `nextjs` (uid 1001) via the existing `chown`, so a fresh named volume inherits correct ownership on first mount instead of `root:root`.
- **`docker-compose.yml`** — mount a named volume (`uv_cache`) at the uv cache directory.

Net diff: 2 files, +11 / −1.

## How to test

1. `docker compose up -d` and connect a STDIO MCP server that uses `uvx <pkg>@latest`. The first spawn cold-installs (slow).
2. `docker compose up -d --force-recreate` the app container.
3. The next `uvx` spawn reuses the cache (fast) instead of cold-installing again — the populated cache survives the recreate, so the slow-spawn → ERROR cycle no longer recurs on every recreate.