### PR TITLE
oauth: implement refresh token issuance and rotation

### DIFF
--- a/apps/backend/drizzle/0014_even_stick.sql
+++ b/apps/backend/drizzle/0014_even_stick.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "oauth_refresh_tokens" (
+	"refresh_token" text PRIMARY KEY NOT NULL,
+	"client_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"scope" text DEFAULT 'admin' NOT NULL,
+	"access_token" text,
+	"replaced_by" text,
+	"revoked_at" timestamp with time zone,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."oauth_clients"("client_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_access_token_oauth_access_tokens_access_token_fk" FOREIGN KEY ("access_token") REFERENCES "public"."oauth_access_tokens"("access_token") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "oauth_refresh_tokens_client_id_idx" ON "oauth_refresh_tokens" USING btree ("client_id");--> statement-breakpoint
+CREATE INDEX "oauth_refresh_tokens_user_id_idx" ON "oauth_refresh_tokens" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "oauth_refresh_tokens_expires_at_idx" ON "oauth_refresh_tokens" USING btree ("expires_at");

--- a/apps/backend/drizzle/meta/0014_snapshot.json
+++ b/apps/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2036 @@
+{
+  "id": "e2b41075-715b-48b6-b118-2cb79b8e5fa5",
+  "prevId": "06d6c80e-47a8-4720-ba08-ec60b13f1098",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_is_active_idx": {
+          "name": "api_keys_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "api_keys_name_per_user_idx": {
+          "name": "api_keys_name_per_user_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config": {
+      "name": "config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.endpoints": {
+      "name": "endpoints",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_api_key_auth": {
+          "name": "enable_api_key_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_oauth": {
+          "name": "enable_oauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_max_rate": {
+          "name": "enable_max_rate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_client_max_rate": {
+          "name": "enable_client_max_rate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_rate": {
+          "name": "max_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_rate_seconds": {
+          "name": "max_rate_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate": {
+          "name": "client_max_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_seconds": {
+          "name": "client_max_rate_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_strategy": {
+          "name": "client_max_rate_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_max_rate_strategy_key": {
+          "name": "client_max_rate_strategy_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_query_param_auth": {
+          "name": "use_query_param_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "endpoints_namespace_uuid_idx": {
+          "name": "endpoints_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "endpoints_user_id_idx": {
+          "name": "endpoints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "endpoints_namespace_uuid_namespaces_uuid_fk": {
+          "name": "endpoints_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "endpoints",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "endpoints_user_id_users_id_fk": {
+          "name": "endpoints_user_id_users_id_fk",
+          "tableFrom": "endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "endpoints_name_unique": {
+          "name": "endpoints_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "mcp_server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STDIO'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_status": {
+          "name": "error_status",
+          "type": "mcp_server_error_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NONE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_type_idx": {
+          "name": "mcp_servers_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_servers_user_id_idx": {
+          "name": "mcp_servers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_servers_error_status_idx": {
+          "name": "mcp_servers_error_status_idx",
+          "columns": [
+            {
+              "expression": "error_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_user_id_users_id_fk": {
+          "name": "mcp_servers_user_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_user_unique_idx": {
+          "name": "mcp_servers_name_user_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespace_server_mappings": {
+      "name": "namespace_server_mappings",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_server_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "namespace_server_mappings_namespace_uuid_idx": {
+          "name": "namespace_server_mappings_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_server_mappings_mcp_server_uuid_idx": {
+          "name": "namespace_server_mappings_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_server_mappings_status_idx": {
+          "name": "namespace_server_mappings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespace_server_mappings_namespace_uuid_namespaces_uuid_fk": {
+          "name": "namespace_server_mappings_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "namespace_server_mappings",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_server_mappings_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "namespace_server_mappings_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "namespace_server_mappings",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespace_server_mappings_unique_idx": {
+          "name": "namespace_server_mappings_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace_uuid",
+            "mcp_server_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespace_tool_mappings": {
+      "name": "namespace_tool_mappings",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace_uuid": {
+          "name": "namespace_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_uuid": {
+          "name": "tool_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_server_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "override_name": {
+          "name": "override_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_title": {
+          "name": "override_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_annotations": {
+          "name": "override_annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "namespace_tool_mappings_namespace_uuid_idx": {
+          "name": "namespace_tool_mappings_namespace_uuid_idx",
+          "columns": [
+            {
+              "expression": "namespace_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_tool_uuid_idx": {
+          "name": "namespace_tool_mappings_tool_uuid_idx",
+          "columns": [
+            {
+              "expression": "tool_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_mcp_server_uuid_idx": {
+          "name": "namespace_tool_mappings_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "namespace_tool_mappings_status_idx": {
+          "name": "namespace_tool_mappings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespace_tool_mappings_namespace_uuid_namespaces_uuid_fk": {
+          "name": "namespace_tool_mappings_namespace_uuid_namespaces_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "namespaces",
+          "columnsFrom": [
+            "namespace_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_tool_mappings_tool_uuid_tools_uuid_fk": {
+          "name": "namespace_tool_mappings_tool_uuid_tools_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "tools",
+          "columnsFrom": [
+            "tool_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "namespace_tool_mappings_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "namespace_tool_mappings_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "namespace_tool_mappings",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespace_tool_mappings_unique_idx": {
+          "name": "namespace_tool_mappings_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace_uuid",
+            "tool_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.namespaces": {
+      "name": "namespaces",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "namespaces_user_id_idx": {
+          "name": "namespaces_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "namespaces_user_id_users_id_fk": {
+          "name": "namespaces_user_id_users_id_fk",
+          "tableFrom": "namespaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "namespaces_name_user_unique_idx": {
+          "name": "namespaces_name_user_unique_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"authorization_code\",\"refresh_token\"}'::text[]"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"code\"}'::text[]"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'admin'"
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_uri": {
+          "name": "tos_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_uri": {
+          "name": "policy_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_access_token_oauth_access_tokens_access_token_fk": {
+          "name": "oauth_refresh_tokens_access_token_oauth_access_tokens_access_token_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_access_tokens",
+          "columnsFrom": [
+            "access_token"
+          ],
+          "columnsTo": [
+            "access_token"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_sessions": {
+      "name": "oauth_sessions",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_sessions_mcp_server_uuid_idx": {
+          "name": "oauth_sessions_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_sessions_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "oauth_sessions_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "oauth_sessions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_sessions_unique_per_server_idx": {
+          "name": "oauth_sessions_unique_per_server_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mcp_server_uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_schema": {
+          "name": "tool_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "mcp_server_uuid": {
+          "name": "mcp_server_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tools_mcp_server_uuid_idx": {
+          "name": "tools_mcp_server_uuid_idx",
+          "columns": [
+            {
+              "expression": "mcp_server_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_mcp_server_uuid_mcp_servers_uuid_fk": {
+          "name": "tools_mcp_server_uuid_mcp_servers_uuid_fk",
+          "tableFrom": "tools",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tools_unique_tool_name_per_server_idx": {
+          "name": "tools_unique_tool_name_per_server_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mcp_server_uuid",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.mcp_server_error_status": {
+      "name": "mcp_server_error_status",
+      "schema": "public",
+      "values": [
+        "NONE",
+        "ERROR"
+      ]
+    },
+    "public.mcp_server_status": {
+      "name": "mcp_server_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.mcp_server_type": {
+      "name": "mcp_server_type",
+      "schema": "public",
+      "values": [
+        "STDIO",
+        "SSE",
+        "STREAMABLE_HTTP"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1766064780578,
       "tag": "0013_late_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1778344008921,
+      "tag": "0014_even_stick",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/oauth.repo.ts
+++ b/apps/backend/src/db/repositories/oauth.repo.ts
@@ -5,6 +5,8 @@ import {
   OAuthAuthorizationCodeCreateInput,
   OAuthClient,
   OAuthClientCreateInput,
+  OAuthRefreshToken,
+  OAuthRefreshTokenCreateInput,
 } from "@repo/zod-types";
 import { eq, lt } from "drizzle-orm";
 
@@ -13,6 +15,7 @@ import {
   oauthAccessTokensTable,
   oauthAuthorizationCodesTable,
   oauthClientsTable,
+  oauthRefreshTokensTable,
 } from "../schema";
 
 export class OAuthRepository {
@@ -103,6 +106,58 @@ export class OAuthRepository {
       .where(eq(oauthAccessTokensTable.access_token, token));
   }
 
+  // ===== Refresh Tokens =====
+
+  async getRefreshToken(token: string): Promise<OAuthRefreshToken | null> {
+    const result = await db
+      .select()
+      .from(oauthRefreshTokensTable)
+      .where(eq(oauthRefreshTokensTable.refresh_token, token))
+      .limit(1);
+    return result[0] || null;
+  }
+
+  async setRefreshToken(
+    token: string,
+    data: OAuthRefreshTokenCreateInput,
+  ): Promise<void> {
+    await db.insert(oauthRefreshTokensTable).values({
+      refresh_token: token,
+      client_id: data.client_id,
+      user_id: data.user_id,
+      scope: data.scope,
+      access_token: data.access_token,
+      expires_at: new Date(data.expires_at),
+    });
+  }
+
+  async deleteRefreshToken(token: string): Promise<void> {
+    await db
+      .delete(oauthRefreshTokensTable)
+      .where(eq(oauthRefreshTokensTable.refresh_token, token));
+  }
+
+  async rotateRefreshToken(
+    oldToken: string,
+    newToken: string,
+    data: OAuthRefreshTokenCreateInput,
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      await tx.insert(oauthRefreshTokensTable).values({
+        refresh_token: newToken,
+        client_id: data.client_id,
+        user_id: data.user_id,
+        scope: data.scope,
+        access_token: data.access_token,
+        expires_at: new Date(data.expires_at),
+      });
+
+      await tx
+        .delete(oauthRefreshTokensTable)
+        .where(eq(oauthRefreshTokensTable.refresh_token, oldToken));
+    });
+  }
+
   // ===== Cleanup =====
 
   async cleanupExpired(): Promise<void> {
@@ -114,6 +169,9 @@ export class OAuthRepository {
       db
         .delete(oauthAccessTokensTable)
         .where(lt(oauthAccessTokensTable.expires_at, now)),
+      db
+        .delete(oauthRefreshTokensTable)
+        .where(lt(oauthRefreshTokensTable.expires_at, now)),
     ]);
   }
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -484,3 +484,33 @@ export const oauthAccessTokensTable = pgTable(
     index("oauth_access_tokens_expires_at_idx").on(table.expires_at),
   ],
 );
+
+// OAuth Refresh Tokens table
+export const oauthRefreshTokensTable = pgTable(
+  "oauth_refresh_tokens",
+  {
+    refresh_token: text("refresh_token").primaryKey(),
+    client_id: text("client_id")
+      .notNull()
+      .references(() => oauthClientsTable.client_id, { onDelete: "cascade" }),
+    user_id: text("user_id")
+      .notNull()
+      .references(() => usersTable.id, { onDelete: "cascade" }),
+    scope: text("scope").notNull().default("admin"),
+    access_token: text("access_token").references(
+      () => oauthAccessTokensTable.access_token,
+      { onDelete: "set null" },
+    ),
+    replaced_by: text("replaced_by"),
+    revoked_at: timestamp("revoked_at", { withTimezone: true }),
+    expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
+    created_at: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("oauth_refresh_tokens_client_id_idx").on(table.client_id),
+    index("oauth_refresh_tokens_user_id_idx").on(table.user_id),
+    index("oauth_refresh_tokens_expires_at_idx").on(table.expires_at),
+  ],
+);

--- a/apps/backend/src/routers/oauth/token.ts
+++ b/apps/backend/src/routers/oauth/token.ts
@@ -1,11 +1,80 @@
 import express from "express";
+import { OAuthClient } from "@repo/zod-types";
 
 import logger from "@/utils/logger";
 
 import { oauthRepository } from "../../db/repositories";
-import { generateSecureAccessToken, rateLimitToken } from "./utils";
+import {
+  generateSecureAccessToken,
+  generateSecureRefreshToken,
+  rateLimitToken,
+} from "./utils";
 
 const tokenRouter = express.Router();
+
+type ClientAuthResult =
+  | { ok: true }
+  | {
+      ok: false;
+      status: number;
+      body: {
+        error: string;
+        error_description: string;
+      };
+    };
+
+function authenticateClient(
+  req: express.Request,
+  clientData: OAuthClient,
+): ClientAuthResult {
+  if (clientData.token_endpoint_auth_method === "client_secret_basic") {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Basic ")) {
+      return {
+        ok: false,
+        status: 401,
+        body: {
+          error: "invalid_client",
+          error_description: "Client authentication required via Basic auth",
+        },
+      };
+    }
+
+    const credentials = Buffer.from(
+      authHeader.substring(6),
+      "base64",
+    ).toString();
+    const [authClientId, authClientSecret] = credentials.split(":");
+
+    if (
+      authClientId !== clientData.client_id ||
+      authClientSecret !== clientData.client_secret
+    ) {
+      return {
+        ok: false,
+        status: 401,
+        body: {
+          error: "invalid_client",
+          error_description: "Invalid client credentials",
+        },
+      };
+    }
+  } else if (clientData.token_endpoint_auth_method === "client_secret_post") {
+    const { client_secret } = req.body;
+    if (!client_secret || client_secret !== clientData.client_secret) {
+      return {
+        ok: false,
+        status: 401,
+        body: {
+          error: "invalid_client",
+          error_description: "Invalid client secret",
+        },
+      };
+    }
+  }
+
+  return { ok: true };
+}
 
 /**
  * OAuth 2.0 Token Endpoint
@@ -29,165 +98,227 @@ tokenRouter.post("/oauth/token", rateLimitToken, async (req, res) => {
       });
     }
 
+    const ACCESS_TTL = parseInt(process.env.OAUTH_ACCESS_TOKEN_TTL_SECONDS ?? "3600", 10);
+    const REFRESH_TTL = parseInt(process.env.OAUTH_REFRESH_TOKEN_TTL_SECONDS ?? "2592000", 10);
     const { grant_type, code, redirect_uri, client_id, code_verifier } =
       req.body;
 
-    // Validate grant type
-    if (grant_type !== "authorization_code") {
-      return res.status(400).json({
-        error: "unsupported_grant_type",
-        error_description: "Only 'authorization_code' grant type is supported",
-      });
-    }
+    switch (grant_type) {
+      case "authorization_code": {
+        if (!code) {
+          return res.status(400).json({
+            error: "invalid_request",
+            error_description: "Missing authorization code",
+          });
+        }
 
-    // Validate authorization code
-    if (!code) {
-      return res.status(400).json({
-        error: "invalid_request",
-        error_description: "Missing authorization code",
-      });
-    }
+        const codeData = await oauthRepository.getAuthCode(code);
+        if (!codeData) {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Invalid or expired authorization code",
+          });
+        }
 
-    // Look up the authorization code
-    const codeData = await oauthRepository.getAuthCode(code);
-    if (!codeData) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Invalid or expired authorization code",
-      });
-    }
+        if (Date.now() > codeData.expires_at.getTime()) {
+          await oauthRepository.deleteAuthCode(code);
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Authorization code has expired",
+          });
+        }
 
-    // Check if code has expired (10 minutes)
-    if (Date.now() > codeData.expires_at.getTime()) {
-      await oauthRepository.deleteAuthCode(code);
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Authorization code has expired",
-      });
-    }
+        if (codeData.client_id !== client_id) {
+          return res.status(400).json({
+            error: "invalid_client",
+            error_description: "Client ID does not match",
+          });
+        }
 
-    // Validate client_id and redirect_uri match the original request
-    if (codeData.client_id !== client_id) {
-      return res.status(400).json({
-        error: "invalid_client",
-        error_description: "Client ID does not match",
-      });
-    }
+        if (codeData.redirect_uri !== redirect_uri) {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Redirect URI does not match",
+          });
+        }
 
-    if (codeData.redirect_uri !== redirect_uri) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Redirect URI does not match",
-      });
-    }
+        const clientData = await oauthRepository.getClient(client_id);
+        if (!clientData) {
+          return res.status(400).json({
+            error: "invalid_client",
+            error_description: "Client not found or not registered",
+          });
+        }
 
-    // Validate client_id against registered clients
-    // Note: Client should have been registered either explicitly via /oauth/register
-    // or auto-registered during the /oauth/authorize flow
-    const clientData = await oauthRepository.getClient(client_id);
-    if (!clientData) {
-      return res.status(400).json({
-        error: "invalid_client",
-        error_description: "Client not found or not registered",
-      });
-    }
+        const auth = authenticateClient(req, clientData);
+        if (!auth.ok) {
+          return res.status(auth.status).json(auth.body);
+        }
 
-    // Validate client authentication based on registered auth method
-    if (clientData.token_endpoint_auth_method === "client_secret_basic") {
-      const authHeader = req.headers.authorization;
-      if (!authHeader || !authHeader.startsWith("Basic ")) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Client authentication required via Basic auth",
+        // OAuth 2.1 Security: PKCE is mandatory for all clients
+        if (!codeData.code_challenge) {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description:
+              "Authorization code was not issued with PKCE challenge",
+          });
+        }
+
+        if (!code_verifier) {
+          return res.status(400).json({
+            error: "invalid_request",
+            error_description: "PKCE code verifier is required",
+          });
+        }
+
+        // Verify code challenge
+        const crypto = await import("crypto");
+        let challengeFromVerifier: string;
+
+        if (codeData.code_challenge_method === "S256") {
+          const hash = crypto
+            .createHash("sha256")
+            .update(code_verifier)
+            .digest();
+          challengeFromVerifier = hash.toString("base64url");
+        } else if (codeData.code_challenge_method === "plain") {
+          challengeFromVerifier = code_verifier;
+        } else {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Unsupported code challenge method",
+          });
+        }
+
+        if (challengeFromVerifier !== codeData.code_challenge) {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "PKCE verification failed",
+          });
+        }
+
+        // Code is valid, delete it (authorization codes are single-use)
+        await oauthRepository.deleteAuthCode(code);
+
+        // Generate access token
+        const accessToken = generateSecureAccessToken();
+        await oauthRepository.setAccessToken(accessToken, {
+          client_id: codeData.client_id,
+          user_id: codeData.user_id,
+          scope: codeData.scope,
+          expires_at: Date.now() + ACCESS_TTL * 1000,
+        });
+
+        const refreshToken = generateSecureRefreshToken();
+        await oauthRepository.setRefreshToken(refreshToken, {
+          client_id: codeData.client_id,
+          user_id: codeData.user_id,
+          scope: codeData.scope,
+          access_token: accessToken,
+          expires_at: Date.now() + REFRESH_TTL * 1000,
+        });
+
+        return res.json({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+          token_type: "Bearer",
+          expires_in: ACCESS_TTL,
+          scope: codeData.scope,
         });
       }
+      case "refresh_token": {
+        const { refresh_token } = req.body;
 
-      const credentials = Buffer.from(
-        authHeader.substring(6),
-        "base64",
-      ).toString();
-      const [authClientId, authClientSecret] = credentials.split(":");
+        if (!refresh_token) {
+          return res.status(400).json({
+            error: "invalid_request",
+            error_description: "Missing refresh token",
+          });
+        }
 
-      if (
-        authClientId !== client_id ||
-        authClientSecret !== clientData.client_secret
-      ) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Invalid client credentials",
+        if (!client_id) {
+          return res.status(400).json({
+            error: "invalid_request",
+            error_description: "Missing client_id",
+          });
+        }
+
+        const rtData = await oauthRepository.getRefreshToken(refresh_token);
+        if (!rtData) {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Invalid or expired refresh token",
+          });
+        }
+
+        if (Date.now() > rtData.expires_at.getTime()) {
+          await oauthRepository.deleteRefreshToken(refresh_token);
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Refresh token expired",
+          });
+        }
+
+        if (rtData.revoked_at) {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Refresh token revoked",
+          });
+        }
+
+        if (rtData.client_id !== client_id) {
+          return res.status(400).json({
+            error: "invalid_grant",
+            error_description: "Client mismatch",
+          });
+        }
+
+        const clientData = await oauthRepository.getClient(client_id);
+        if (!clientData) {
+          return res.status(400).json({
+            error: "invalid_client",
+            error_description: "Client not found or not registered",
+          });
+        }
+
+        const auth = authenticateClient(req, clientData);
+        if (!auth.ok) {
+          return res.status(auth.status).json(auth.body);
+        }
+
+        // TODO(v1.1): enforce reuse detection per OAuth 2.1 BCP §4.13
+
+        const newAccess = generateSecureAccessToken();
+        const newRefresh = generateSecureRefreshToken();
+
+        await oauthRepository.setAccessToken(newAccess, {
+          client_id: rtData.client_id,
+          user_id: rtData.user_id,
+          scope: rtData.scope,
+          expires_at: Date.now() + ACCESS_TTL * 1000,
+        });
+        await oauthRepository.rotateRefreshToken(refresh_token, newRefresh, {
+          client_id: rtData.client_id,
+          user_id: rtData.user_id,
+          scope: rtData.scope,
+          access_token: newAccess,
+          expires_at: Date.now() + REFRESH_TTL * 1000,
+        });
+
+        return res.json({
+          access_token: newAccess,
+          refresh_token: newRefresh,
+          token_type: "Bearer",
+          expires_in: ACCESS_TTL,
+          scope: rtData.scope,
         });
       }
-    } else if (clientData.token_endpoint_auth_method === "client_secret_post") {
-      const { client_secret } = req.body;
-      if (!client_secret || client_secret !== clientData.client_secret) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Invalid client secret",
+      default:
+        return res.status(400).json({
+          error: "unsupported_grant_type",
+          error_description: "Supported grant types: authorization_code, refresh_token",
         });
-      }
     }
-    // For "none" auth method, no additional validation needed
-
-    // OAuth 2.1 Security: PKCE is mandatory for all clients
-    if (!codeData.code_challenge) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description:
-          "Authorization code was not issued with PKCE challenge",
-      });
-    }
-
-    if (!code_verifier) {
-      return res.status(400).json({
-        error: "invalid_request",
-        error_description: "PKCE code verifier is required",
-      });
-    }
-
-    // Verify code challenge
-    const crypto = await import("crypto");
-    let challengeFromVerifier: string;
-
-    if (codeData.code_challenge_method === "S256") {
-      const hash = crypto.createHash("sha256").update(code_verifier).digest();
-      challengeFromVerifier = hash.toString("base64url");
-    } else if (codeData.code_challenge_method === "plain") {
-      challengeFromVerifier = code_verifier;
-    } else {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Unsupported code challenge method",
-      });
-    }
-
-    if (challengeFromVerifier !== codeData.code_challenge) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "PKCE verification failed",
-      });
-    }
-
-    // Code is valid, delete it (authorization codes are single-use)
-    await oauthRepository.deleteAuthCode(code);
-
-    // Generate access token
-    const accessToken = generateSecureAccessToken();
-    const expiresIn = 3600; // 1 hour
-
-    // Store access token data
-    await oauthRepository.setAccessToken(accessToken, {
-      client_id: codeData.client_id,
-      user_id: codeData.user_id,
-      scope: codeData.scope,
-      expires_at: Date.now() + expiresIn * 1000,
-    });
-
-    res.json({
-      access_token: accessToken,
-      token_type: "Bearer",
-      expires_in: expiresIn,
-      scope: codeData.scope,
-    });
   } catch (error) {
     logger.error("Error in OAuth token endpoint:", error);
     res.status(500).json({

--- a/apps/backend/src/routers/oauth/utils.ts
+++ b/apps/backend/src/routers/oauth/utils.ts
@@ -32,6 +32,15 @@ export function generateSecureAccessToken(): string {
 }
 
 /**
+ * Generate cryptographically secure refresh token
+ * Follows OAuth 2.1 security requirements
+ */
+export function generateSecureRefreshToken(): string {
+  const randomPart = randomBytes(32).toString("base64url");
+  return `mcp_refresh_${randomPart}`;
+}
+
+/**
  * Generate cryptographically secure client ID
  * Follows OAuth 2.1 security requirements
  */

--- a/example.env
+++ b/example.env
@@ -151,3 +151,7 @@ BOOTSTRAP_ENDPOINTS=[{"name":"Public","description":"Public endpoint","enable_au
 # Extra trusted origins for Better Auth (comma-separated)
 # Useful for cluster deployments where different ports/origins are needed
 # EXTRA_TRUSTED_ORIGINS=http://myapp.example.com,http://myapp.example.com:8080
+
+# OAuth token lifetimes (seconds). Defaults: 1h access, 30d refresh.
+# OAUTH_ACCESS_TOKEN_TTL_SECONDS=3600
+# OAUTH_REFRESH_TOKEN_TTL_SECONDS=2592000

--- a/packages/zod-types/src/oauth.zod.ts
+++ b/packages/zod-types/src/oauth.zod.ts
@@ -61,6 +61,19 @@ export const OAuthAccessTokenSchema = z.object({
   created_at: z.date(),
 });
 
+// OAuth Refresh Token schema
+export const OAuthRefreshTokenSchema = z.object({
+  refresh_token: z.string(),
+  client_id: z.string(),
+  user_id: z.string(),
+  scope: z.string(),
+  access_token: z.string().nullable(),
+  replaced_by: z.string().nullable(),
+  revoked_at: z.date().nullable(),
+  expires_at: z.date(),
+  created_at: z.date(),
+});
+
 // Input schemas for repositories
 export const OAuthClientCreateInputSchema = z.object({
   client_id: z.string(),
@@ -96,6 +109,14 @@ export const OAuthAccessTokenCreateInputSchema = z.object({
   client_id: z.string(),
   user_id: z.string(),
   scope: z.string(),
+  expires_at: z.number(), // timestamp
+});
+
+export const OAuthRefreshTokenCreateInputSchema = z.object({
+  client_id: z.string(),
+  user_id: z.string(),
+  scope: z.string(),
+  access_token: z.string().nullable(),
   expires_at: z.number(), // timestamp
 });
 
@@ -199,4 +220,8 @@ export type OAuthAuthorizationCodeCreateInput = z.infer<
 export type OAuthAccessToken = z.infer<typeof OAuthAccessTokenSchema>;
 export type OAuthAccessTokenCreateInput = z.infer<
   typeof OAuthAccessTokenCreateInputSchema
+>;
+export type OAuthRefreshToken = z.infer<typeof OAuthRefreshTokenSchema>;
+export type OAuthRefreshTokenCreateInput = z.infer<
+  typeof OAuthRefreshTokenCreateInputSchema
 >;


### PR DESCRIPTION
## Problem

The `/oauth/token` endpoint advertises `refresh_token` grant support in the `.well-known` metadata (`metadata.ts`) but only handles `authorization_code`, returning a 1-hour access token with no `refresh_token`. claude.ai (and any spec-compliant MCP client) therefore has no way to extend the session, so the connector drops to "disconnected" within an hour and demands re-authentication. The implementation now matches what the metadata already advertises.

## Changes

- Add `oauth_refresh_tokens` table (FK to clients/users/access_tokens, with forward-compat `replaced_by` + `revoked_at` columns for reuse-detection per OAuth 2.1 BCP §4.13). New migration `0014_even_stick.sql` (slots after upstream's `0013`).
- Add `generateSecureRefreshToken()` helper in `utils`.
- Add `getRefreshToken` / `setRefreshToken` / `deleteRefreshToken` plus an atomic `rotateRefreshToken` (`db.transaction` insert+delete). Extend `cleanupExpired` to purge expired refresh tokens.
- Refactor `/oauth/token`: extract an `authenticateClient` helper for the `client_secret_basic` / `_post` / `none` branches; split `grant_type` into `authorization_code` (now also issues a `refresh_token`) and `refresh_token` (validate + rotate atomically + mint a new access token) branches.
- Read `OAUTH_ACCESS_TOKEN_TTL_SECONDS` (default 3600) and `OAUTH_REFRESH_TOKEN_TTL_SECONDS` (default 2592000 = 30d) from env so TTLs are tunable without a code change. Documented in `example.env`.
- Add `OAuthRefreshTokenSchema` + create-input + types in `zod-types`.

## How to test

1. Run the new migration (`pnpm` drizzle migrate / on container start).
2. Complete an OAuth authorization-code flow from an MCP client (e.g. claude.ai). The token response now includes a `refresh_token`.
3. Exchange that `refresh_token` at `/oauth/token` with `grant_type=refresh_token` — it returns a new access token and a rotated refresh token; the old refresh token is invalidated.
4. Confirm the connector stays connected past the 1-hour access-token TTL instead of dropping to "disconnected".