### PR TITLE
fix(docker): repair image build on pnpm 10 + current react resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,15 @@ COPY . .
 # Build all packages and apps
 RUN pnpm build
 
-RUN sed -i -e "s/30000/600000/" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/server/lib/router-utils/proxy-request.js" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/esm/server/lib/router-utils/proxy-request.js"
+# Bump Next.js dev proxy timeout 30s -> 600s. The pnpm store dir for `next`
+# embeds the resolved react/react-dom versions, so we glob it instead of
+# hardcoding (a hardcoded path silently breaks on every react/next bump).
+RUN found=0; \
+    for f in node_modules/.pnpm/next@*/node_modules/next/dist/server/lib/router-utils/proxy-request.js \
+             node_modules/.pnpm/next@*/node_modules/next/dist/esm/server/lib/router-utils/proxy-request.js; do \
+      if [ -f "$f" ]; then sed -i -e "s/30000/600000/" "$f"; found=1; fi; \
+    done; \
+    if [ "$found" = 0 ]; then echo "WARN: next proxy-request.js not found; timeout patch skipped"; fi
 
 # Production runner stage
 FROM base AS runner
@@ -86,11 +92,27 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/package.json ./
 COPY --from=builder --chown=nextjs:nodejs /app/pnpm-workspace.yaml ./
 
-# Install production dependencies only
-RUN pnpm install --prod
+# drizzle-kit is a backend devDependency but is required at runtime for
+# `pnpm exec drizzle-kit migrate` (see docker-entrypoint.sh). `pnpm install --prod`
+# prunes devDependencies, so promote it to a prod dependency first; the prod
+# install below then keeps it and links its bin. (A separate `pnpm add
+# drizzle-kit --prod` no-ops because it is an already-satisfied devDep, leaving
+# no binary and breaking migrations at startup.)
+RUN cd apps/backend \
+    && pnpm pkg set dependencies.drizzle-kit="^0.31.1" \
+    && pnpm pkg delete devDependencies.drizzle-kit
 
-# Install drizzle-kit locally in backend for migrations
-RUN cd apps/backend && pnpm add drizzle-kit@0.31.1
+# Install production dependencies only.
+# pnpm >=10 refuses to purge the copied node_modules without a TTY
+# (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY) during a non-interactive Docker
+# build. Disable the purge confirmation: pnpm v10 reads npm_config_*, v11 reads
+# pnpm_config_* (set both), and CI=true makes pnpm treat the build as
+# non-interactive. --no-frozen-lockfile lets pnpm reconcile the drizzle-kit
+# promotion above.
+ENV CI=true \
+    npm_config_confirm_modules_purge=false \
+    pnpm_config_confirm_modules_purge=false
+RUN pnpm install --prod --no-frozen-lockfile
 
 # Copy startup script
 COPY --chown=nextjs:nodejs docker-entrypoint.sh ./


### PR DESCRIPTION
## Summary

A from-scratch `docker build .` of `ai-dev` currently fails at **three** separate steps. They're easy to miss because the image is only built on release tags (`docker-publish.yml` triggers on `v*`), and the dependency bumps that introduced these failures landed on `ai-dev` after the last tagged Docker release — so the breakage is latent rather than shipped. The next release cut from `ai-dev` will hit all three.

None of these are environment-specific:
- the pnpm version is **pinned in the Dockerfile** (`npm install -g pnpm@10.12.0`), and
- the react/react-dom resolution is **fixed by `pnpm-lock.yaml`** (now 19.2.4).

So this reproduces for anyone building the image, on CI or locally.

## The three failures and fixes

**1. Stale hardcoded `next` pnpm store path** (`sed` step, builder stage)

The proxy-timeout patch targeted `node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/...`, but the lockfile now resolves react/react-dom to **19.2.4**, so that directory doesn't exist and `sed` exits non-zero. Fixed by globbing the `next@*` store dir and warning (not failing) if the file is absent — which also prevents this from silently breaking on every future react/next bump.

**2. `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`** (`RUN pnpm install --prod`, runner stage)

pnpm ≥10 prompts before purging `node_modules` and aborts when there's no TTY — i.e. every non-interactive `docker build`. Fixed by disabling the purge confirmation via env (`npm_config_confirm_modules_purge` for v10, `pnpm_config_confirm_modules_purge` for v11), with `CI=true` as a backstop.

**3. `drizzle-kit` missing at runtime for migrations** (runner stage)

`drizzle-kit` is a backend **devDependency**, but `docker-entrypoint.sh` runs `pnpm exec drizzle-kit migrate` at container startup. `pnpm install --prod` prunes it, so the container starts and then crash-loops with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "drizzle-kit" not found`. Fixed by **promoting drizzle-kit to a prod dependency before the prod install**, so it's kept and its bin is linked; `--no-frozen-lockfile` lets pnpm reconcile the promotion.

> Note: a tempting one-liner — `pnpm add drizzle-kit@0.31.1 --prod` after the prune — builds green but is wrong: it no-ops because drizzle-kit is an already-satisfied devDep and `--prod` skips dev deps, so no binary is linked and migrations fail at startup. The promotion approach was verified at runtime (`pnpm exec drizzle-kit --version` → `0.31.1` inside the built image).

## Notes for reviewers

- I put the env vars in a single `ENV` for the runner stage; happy to scope them inline to the `RUN pnpm install --prod` instead if you'd rather not persist `CI=true` into the runtime image.
- You may also want to reconcile the pnpm versions: the Dockerfile installs `pnpm@10.12.0` (which npm's registry flags as broken — *"Use 10.12.1"*) while `package.json` `packageManager` declares `pnpm@10.29.3`. This PR is intentionally version-agnostic — the fixes hold on any pnpm 10/11 — but aligning those would be a sensible follow-up.

## Testing

Built green end-to-end as a multi-arch image (`linux/amd64,linux/arm64`) via `docker buildx`, **and** verified the resulting container starts and runs migrations (drizzle-kit resolves and `drizzle-kit migrate` executes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)