### PR TITLE
Fix Docker build on current lockfile and Windows clones

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts are executed inside Linux containers; a CRLF checkout on
+# Windows breaks the shebang of the COPY'd entrypoint ("no such file or directory").
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,11 @@ COPY . .
 # Build all packages and apps
 RUN pnpm build
 
-RUN sed -i -e "s/30000/600000/" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/server/lib/router-utils/proxy-request.js" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/esm/server/lib/router-utils/proxy-request.js"
+# Locate proxy-request.js dynamically: the .pnpm dir name embeds peer-dep
+# versions (react etc.) and goes stale whenever the lockfile bumps them.
+RUN files="$(find node_modules/.pnpm -path '*/next/dist/*lib/router-utils/proxy-request.js')" && \
+    test -n "$files" && \
+    sed -i -e "s/30000/600000/" $files
 
 # Production runner stage
 FROM base AS runner
@@ -86,11 +88,16 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/package.json ./
 COPY --from=builder --chown=nextjs:nodejs /app/pnpm-workspace.yaml ./
 
-# Install production dependencies only
-RUN pnpm install --prod
+# Install drizzle-kit locally in backend for migrations. Must run BEFORE the
+# --prod prune (pnpm add requires the modules dir's include set — still
+# dev-included from the builder copy — to match), and with -P: backend's
+# package.json already has drizzle-kit in devDependencies, so a plain add
+# updates it in place there and the prune below would delete it.
+RUN cd apps/backend && CI=true pnpm add -P drizzle-kit@0.31.1
 
-# Install drizzle-kit locally in backend for migrations
-RUN cd apps/backend && pnpm add drizzle-kit@0.31.1
+# Install production dependencies only (CI=true: pnpm prompts before
+# pruning the copied dev node_modules and there is no TTY in docker build)
+RUN CI=true pnpm install --prod
 
 # Copy startup script
 COPY --chown=nextjs:nodejs docker-entrypoint.sh ./


### PR DESCRIPTION
## Problem

`docker compose build` fails from a fresh clone, with three independent errors, and on Windows clones the resulting container crash-loops even after a successful build.

1. **Stale pnpm store path in the `sed` patch step.** The hardcoded `.pnpm` directory name embeds peer-dep versions (`next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2`), but the lockfile has moved to react 19.2.4, so the directory doesn't exist and the build fails with exit code 2.
2. **`pnpm install --prod` aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.** pnpm prompts before pruning the dev `node_modules` copied from the builder stage, and `docker build` has no TTY.
3. **drizzle-kit missing at runtime.** `apps/backend/package.json` lists `drizzle-kit` in `devDependencies`, so the post-prune `pnpm add` hits `ERR_PNPM_INCLUDED_DEPS_CONFLICT` (the modules dir was installed prod-only). Naively reordering add-before-prune isn't enough either: a plain `pnpm add` updates the existing devDependencies entry in place and the prune then deletes the binary again, failing migrations at startup with `Command "drizzle-kit" not found`.
4. **CRLF checkout breaks the entrypoint on Windows.** With `core.autocrlf=true` (the Git for Windows default), `docker-entrypoint.sh` checks out with CRLF line endings, gets COPY'd into the image as-is, and the container dies in a restart loop with `exec ./docker-entrypoint.sh: no such file or directory` (shebang interpreter path ends in `\r`).

## Fixes

- Locate `proxy-request.js` dynamically with `find` instead of the hardcoded store path, and fail the build loudly if it's ever missing (so the timeout patch can't silently stop applying).
- Run the prod install with `CI=true` so pnpm never prompts.
- Install drizzle-kit **before** the prune (matching the modules dir's dev-included state) and with `-P` so it moves from `devDependencies` to `dependencies` and survives `pnpm install --prod`.
- Add `.gitattributes` forcing LF for `*.sh` so Windows clones produce working images.

## Testing

Built and ran on Windows 11 + Docker Desktop (engine 29.x) from a fresh clone: full `docker compose build` succeeds, migrations run, bootstrap completes, and the streamable-HTTP endpoint serves a namespace with a STDIO server end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)