### PR TITLE
Patch Next.js proxy-request timeout to 600s in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,15 @@ COPY . .
 # Build all packages and apps
 RUN pnpm build
 
-RUN sed -i -e "s/30000/600000/" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/server/lib/router-utils/proxy-request.js" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/esm/server/lib/router-utils/proxy-request.js"
+# Patch Next.js proxy-request timeout from 30s to 600s
+# Use glob to find Next.js proxy-request.js regardless of pnpm store layout
+RUN for f in $(find /app -type f \( \
+      -path "*/.pnpm/next@*/node_modules/next/dist/server/lib/router-utils/proxy-request.js" -o \
+      -path "*/.pnpm/next@*/node_modules/next/dist/esm/server/lib/router-utils/proxy-request.js" \
+    \) 2>/dev/null); do \
+      sed -i -e "s/30000/600000/" "$f"; \
+      echo "Patched: $f"; \
+    done
 
 # Production runner stage
 FROM base AS runner


### PR DESCRIPTION
This pull request updates the way the Next.js proxy request timeout is patched in the `Dockerfile` to be more robust against changes in the pnpm store layout. Instead of hardcoding the file paths, it now uses a `find` command to dynamically locate and patch all relevant `proxy-request.js` files.

**Build process improvements:**

* Updated the `Dockerfile` to use a `find` command that searches for all `proxy-request.js` files in the pnpm store and patches the timeout value from 30s to 600s, making the patching process more reliable across different pnpm layouts.Updated Dockerfile to patch Next.js proxy-request timeout using glob for file discovery.