### PR TITLE
feat(proxy): MCP_LIST_STRICT — fail aggregate list requests instead of returning an empty success

### DIFF
--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -108,6 +108,23 @@ export const configService = {
     );
   },
 
+  async isMcpListStrict(): Promise<boolean> {
+    const config = await configRepo.getConfig(
+      ConfigKeyEnum.enum.MCP_LIST_STRICT,
+    );
+    // Default to false: preserve the existing behaviour (a degraded aggregate
+    // list is still returned) for everyone who has not opted in.
+    return config?.value === "true";
+  },
+
+  async setMcpListStrict(strict: boolean): Promise<void> {
+    await configRepo.setConfig(
+      ConfigKeyEnum.enum.MCP_LIST_STRICT,
+      strict.toString(),
+      "Whether an aggregate list request fails instead of returning an empty result when every backend server failed",
+    );
+  },
+
   async getSessionLifetime(): Promise<number | null> {
     const config = await configRepo.getConfig(
       ConfigKeyEnum.enum.SESSION_LIFETIME,

--- a/apps/backend/src/lib/metamcp/list-strict.test.ts
+++ b/apps/backend/src/lib/metamcp/list-strict.test.ts
@@ -1,0 +1,54 @@
+import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+
+import { listStrictError } from "./list-strict";
+
+describe("listStrictError", () => {
+  it("returns null when every server answered", () => {
+    expect(listStrictError("tools/list", "ns-1", [], 42)).toBeNull();
+  });
+
+  it("returns null when nothing failed and the namespace is genuinely empty", () => {
+    // A namespace with no servers legitimately aggregates to zero results.
+    // That is not a degraded response and must never become an error.
+    expect(listStrictError("tools/list", "ns-1", [], 0)).toBeNull();
+  });
+
+  it("returns null for a partial result, even with failures", () => {
+    // Partial truth beats a hard failure: the surviving servers' tools are
+    // still useful, so a caller that asked for strictness must NOT get an
+    // error here.
+    expect(listStrictError("tools/list", "ns-1", ["server-a"], 7)).toBeNull();
+  });
+
+  it("returns an error when the result is empty and a server failed", () => {
+    const error = listStrictError("tools/list", "ns-1", ["server-a"], 0);
+
+    expect(error).not.toBeNull();
+    expect(error?.code).toBe(ErrorCode.InternalError);
+    expect(error?.message).toContain("tools/list");
+    expect(error?.message).toContain("ns-1");
+    expect(error?.message).toContain("server-a");
+  });
+
+  it("names every failed server so the log identifies the culprits", () => {
+    const error = listStrictError(
+      "tools/list",
+      "ns-1",
+      ["server-a", "server-b", "server-c"],
+      0,
+    );
+
+    expect(error?.message).toContain("all 3 backend server(s) failed");
+    expect(error?.message).toContain("server-a, server-b, server-c");
+  });
+
+  it("reports the method it was called for", () => {
+    // The same helper guards tools/prompts/resources/templates; the error must
+    // say which one failed rather than always claiming tools/list.
+    const error = listStrictError("resources/list", "ns-2", ["server-a"], 0);
+
+    expect(error?.message).toContain("resources/list");
+    expect(error?.message).not.toContain("tools/list");
+  });
+});

--- a/apps/backend/src/lib/metamcp/list-strict.ts
+++ b/apps/backend/src/lib/metamcp/list-strict.ts
@@ -1,0 +1,35 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Decide whether a fully-degraded aggregate list must be reported as an error.
+ *
+ * The degraded-response tripwire in the list handlers already logs when a
+ * backend server drops out of an aggregate response. But when EVERY server
+ * fails, the client receives an empty list with no error at all: from the
+ * client's side that is indistinguishable from "this namespace legitimately
+ * has no tools". A client starting up during a backend restart therefore sees
+ * nothing and is told nothing — it cannot even retry, because as far as it
+ * knows the request succeeded.
+ *
+ * Returns the error to throw, or null when the response should stand as-is.
+ * Deliberately pure (no config lookup, no I/O) so the decision is directly
+ * testable; the caller gates it on the MCP_LIST_STRICT config key.
+ *
+ * Partial results are deliberately NOT turned into errors: if at least one
+ * server answered, that partial truth still beats a hard failure — the
+ * tradeoff the existing tripwire comment documents.
+ */
+export function listStrictError(
+  method: string,
+  namespaceUuid: string,
+  failedServers: string[],
+  resultCount: number,
+): McpError | null {
+  if (failedServers.length === 0) return null;
+  if (resultCount > 0) return null;
+
+  return new McpError(
+    ErrorCode.InternalError,
+    `${method} failed for namespace ${namespaceUuid}: all ${failedServers.length} backend server(s) failed (${failedServers.join(", ")}) and no results could be aggregated`,
+  );
+}

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -38,6 +38,7 @@ import { ConnectedClient } from "./client";
 import { getMcpServers } from "./fetch-metamcp";
 import { extractForwardedHeaders, mergeHeaders } from "./header-forwarding";
 import { requestWithSessionRecovery } from "./list-handler-recovery";
+import { listStrictError } from "./list-strict";
 import { mcpServerPool } from "./mcp-server-pool";
 import { createAuditCallToolMiddleware } from "./metamcp-middleware/audit-requests.functional";
 import {
@@ -60,6 +61,31 @@ import { isBackendSessionLostError } from "./session-error";
 import { parseToolName } from "./tool-name-parser";
 import { toolsSyncCache } from "./tools-sync-cache";
 import { sanitizeName } from "./utils";
+
+/**
+ * Throw when an aggregate list is fully degraded and MCP_LIST_STRICT is on.
+ *
+ * Opt-in: the config key defaults to false, so the existing behaviour (return
+ * the degraded response as a success) is unchanged for anyone who has not
+ * enabled it. The decision itself lives in `listStrictError`.
+ */
+async function failIfListFullyDegraded(
+  method: string,
+  namespaceUuid: string,
+  failedServers: string[],
+  resultCount: number,
+): Promise<void> {
+  const error = listStrictError(
+    method,
+    namespaceUuid,
+    failedServers,
+    resultCount,
+  );
+  if (!error) return;
+  if (!(await configService.isMcpListStrict())) return;
+
+  throw error;
+}
 
 /**
  * Filter out tools that are overrides of existing tools to prevent duplicates in database
@@ -430,6 +456,13 @@ export const createServer = async (
         `tools/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length}/${allServerEntries.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allTools.length} tools`,
       );
     }
+
+    await failIfListFullyDegraded(
+      "tools/list",
+      namespaceUuid,
+      failedServers,
+      allTools.length,
+    );
 
     return { tools: allTools };
   };
@@ -878,6 +911,13 @@ export const createServer = async (
       );
     }
 
+    await failIfListFullyDegraded(
+      "prompts/list",
+      namespaceUuid,
+      failedServers,
+      allPrompts.length,
+    );
+
     return {
       prompts: allPrompts,
       nextCursor: request.params?.cursor,
@@ -1023,6 +1063,13 @@ export const createServer = async (
         `resources/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allResources.length} resources`,
       );
     }
+
+    await failIfListFullyDegraded(
+      "resources/list",
+      namespaceUuid,
+      failedServers,
+      allResources.length,
+    );
 
     return {
       resources: allResources,
@@ -1204,6 +1251,13 @@ export const createServer = async (
           `resources/templates/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allTemplates.length} templates`,
         );
       }
+
+      await failIfListFullyDegraded(
+        "resources/templates/list",
+        namespaceUuid,
+        failedServers,
+        allTemplates.length,
+      );
 
       return {
         resourceTemplates: allTemplates,

--- a/packages/zod-types/src/config.zod.ts
+++ b/packages/zod-types/src/config.zod.ts
@@ -9,6 +9,7 @@ export const ConfigKeyEnum = z.enum([
   "MCP_TIMEOUT",
   "MCP_MAX_TOTAL_TIMEOUT",
   "MCP_MAX_ATTEMPTS",
+  "MCP_LIST_STRICT",
   "SESSION_LIFETIME",
 ]);
 


### PR DESCRIPTION
## Problem

The degraded-response tripwire added in *"fix(proxy): invalidate-and-retry recovery in the aggregate list handlers"* logs when a backend server drops out of an aggregate list, but the response is still returned as a **success**. When *every* backend fails, the client receives `{ tools: [] }` with no error at all.

From the client's side that is indistinguishable from *"this namespace legitimately has no tools"*. A client starting up while the backends are restarting sees nothing and is told nothing — it cannot even retry, because as far as it knows the request succeeded. The only trace is a `Session not found` line in the gateway's own logs.

We hit this in production. After a host reboot, our aggregated endpoints served **0 tools with no error for ~18s** (measured across two reboots: 17.9s and 19.0s to convergence, with a probe started ~7s after boot). Every MCP client that came up in that window started with an empty tool list and no indication anything was wrong. It looked exactly like a healthy gateway serving empty namespaces.

## What this adds

An opt-in `MCP_LIST_STRICT` config key (**default `false`**, so existing behaviour is unchanged for everyone who doesn't enable it).

When enabled, an aggregate list handler throws `McpError(ErrorCode.InternalError, ...)` instead of returning an empty result — but **only** when the result set is empty **and** at least one server failed.

Deliberately *not* covered:

- **Partial results are never turned into errors.** If any server answered, that partial truth still beats a hard failure — the tradeoff the existing tripwire comment already documents.
- **A genuinely empty namespace never errors.** No failures means no error, regardless of the setting.

Applied to all four aggregate list handlers (tools, prompts, resources, resource templates) so the behaviour cannot drift between them.

This follows the design note already in `list-handler-recovery.ts`:

> the caller decides whether that excludes one server from an aggregate response (and tracks it as degraded) **or fails the request**

The strict variant was anticipated there but not implemented.

## Structure

The decision itself lives in a dependency-free `listStrictError()` helper (`list-strict.ts`), so it is directly unit-testable without a database or config layer. `failIfListFullyDegraded()` in the proxy is the thin wrapper that reads the config key.

Six tests cover the cases that matter — notably the two that must **not** error: an empty namespace with no failures, and a partial result with failures.

## Verification

- **152 tests pass** (146 before + 6 new)
- `eslint . --max-warnings 0` — clean
- `prettier --check` — no changes
- backend `check-types` — passes

The 4 failing test files and the frontend `check-types` failure are **pre-existing**: they reproduce identically on a clean checkout of the base branch (unresolved `@repo/*` workspace types under a bare `pnpm install`), and were confirmed as baseline before attributing anything to this change.

Not verified: runtime behaviour with the flag enabled against a live gateway — that would require building the image, so this rests on unit coverage.

## Note

Happy to adjust the semantics if you'd prefer something different — e.g. erroring on *any* failed server rather than only on total failure, or exposing the key in the Settings UI alongside the other `MCP_*` config keys. The current shape was chosen to be the most conservative thing that still fixes the silent case.
