### PR TITLE
fix(oauth): allow native loopback redirect URIs

### DIFF
--- a/apps/backend/src/routers/oauth/registration.ts
+++ b/apps/backend/src/routers/oauth/registration.ts
@@ -61,7 +61,7 @@ registrationRouter.post("/oauth/register", rateLimitToken, async (req, res) => {
       if (!validateRedirectUri(uri)) {
         return res.status(400).json({
           error: "invalid_redirect_uri",
-          error_description: `Invalid redirect URI: ${uri}. Must use secure scheme and valid format.`,
+          error_description: `Invalid redirect URI: ${uri}. Use HTTPS, or HTTP with localhost, 127.0.0.1, or [::1] for native loopback redirects in production.`,
         });
       }
     }
@@ -218,7 +218,7 @@ registrationRouter.get("/oauth/register", async (req, res) => {
 
       required_parameters: {
         redirect_uris:
-          "Array of redirect URIs for your application (HTTPS required in production)",
+          "Array of redirect URIs for your application (HTTPS required in production, except HTTP native loopback redirects using localhost, 127.0.0.1, or [::1])",
       },
 
       optional_parameters: {
@@ -237,7 +237,8 @@ registrationRouter.get("/oauth/register", async (req, res) => {
 
       security_recommendations: {
         use_pkce: "Always use PKCE (token_endpoint_auth_method: 'none')",
-        https_only: "Use HTTPS redirect URIs in production",
+        https_only:
+          "Use HTTPS redirect URIs in production, except HTTP native loopback redirects using localhost, 127.0.0.1, or [::1]",
         secure_storage:
           "Store client credentials securely if using client authentication",
         code_challenge_method: "Use 'S256' for code_challenge_method",

--- a/apps/backend/src/routers/oauth/utils.test.ts
+++ b/apps/backend/src/routers/oauth/utils.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { validateRedirectUri } from "./utils";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("validateRedirectUri", () => {
+  it.each([
+    "http://LOCALHOST:49152/callback",
+    "http://127.0.0.1:49153/callback",
+    "http://[::1]:49154/callback",
+    "http://[0:0:0:0:0:0:0:1]:49155/callback",
+  ])(
+    "accepts an HTTP native loopback redirect URI in production: %s",
+    (uri) => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      expect(validateRedirectUri(uri)).toBe(true);
+    },
+  );
+
+  it.each([
+    "http://example.com:49152/callback",
+    "http://192.168.1.10:49152/callback",
+    "http://10.0.0.10:49152/callback",
+    "http://172.16.0.10:49152/callback",
+    "http://169.254.169.254:49152/callback",
+    "http://[fd00::1]:49152/callback",
+    "http://localhost.:49152/callback",
+  ])("rejects a non-loopback HTTP redirect URI in production: %s", (uri) => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(validateRedirectUri(uri)).toBe(false);
+  });
+
+  it.each([
+    "https://localhost/callback",
+    "https://127.0.0.1/callback",
+    "https://[::1]/callback",
+  ])("rejects an HTTPS loopback redirect URI in production: %s", (uri) => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(validateRedirectUri(uri)).toBe(false);
+  });
+
+  it("accepts a public HTTPS redirect URI in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(validateRedirectUri("https://example.com/callback")).toBe(true);
+  });
+
+  it("applies allowedHosts to HTTP loopback redirect URIs in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(
+      validateRedirectUri("http://localhost:49152/callback", ["localhost"]),
+    ).toBe(true);
+    expect(
+      validateRedirectUri("http://localhost:49152/callback", ["example.com"]),
+    ).toBe(false);
+  });
+
+  it("preserves non-production support for HTTP redirect URIs", () => {
+    vi.stubEnv("NODE_ENV", "test");
+
+    expect(validateRedirectUri("http://192.168.1.10:49152/callback")).toBe(
+      true,
+    );
+  });
+});

--- a/apps/backend/src/routers/oauth/utils.ts
+++ b/apps/backend/src/routers/oauth/utils.ts
@@ -74,24 +74,29 @@ export function validateRedirectUri(
       return false;
     }
 
-    // For production, only allow HTTPS
-    if (
-      process.env.NODE_ENV === "production" &&
-      parsedUri.protocol !== "https:"
-    ) {
-      return false;
-    }
+    const hostname = parsedUri.hostname.toLowerCase();
+    // URL.hostname normalizes IPv6 loopback to "[::1]".
+    const isLoopbackHost =
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "[::1]";
+    const isHttpLoopbackRedirect =
+      parsedUri.protocol === "http:" && isLoopbackHost;
 
-    // Prevent localhost/private IPs in production
+    // Production permits HTTP only for native loopback redirects.
     if (process.env.NODE_ENV === "production") {
-      const hostname = parsedUri.hostname.toLowerCase();
+      if (parsedUri.protocol !== "https:" && !isHttpLoopbackRedirect) {
+        return false;
+      }
+
+      // Do not allow local/private HTTPS redirects. HTTP loopback redirects
+      // are the exception above, but still pass through allowedHosts below.
       if (
-        hostname === "localhost" ||
-        hostname === "127.0.0.1" ||
-        hostname === "::1" ||
-        hostname.startsWith("192.168.") ||
-        hostname.startsWith("10.") ||
-        hostname.startsWith("172.")
+        !isHttpLoopbackRedirect &&
+        (isLoopbackHost ||
+          hostname.startsWith("192.168.") ||
+          hostname.startsWith("10.") ||
+          hostname.startsWith("172."))
       ) {
         return false;
       }


### PR DESCRIPTION
## Summary

- Allow native-client HTTP loopback redirect URIs in production for `http://localhost:<ephemeral>`, `http://127.0.0.1:<ephemeral>`, and `http://[::1]:<ephemeral>`.
- Continue rejecting all other HTTP redirect URIs in production; the existing HTTPS private/loopback-host policy remains in place.
- Update Dynamic Client Registration (DCR) validation and discovery copy to describe the native loopback exception.
- Fix the former IPv6 loopback check: Node's `URL.hostname` normalizes the host to `[::1]`, so the previous `::1` comparison did not match.

## Security

- The loopback exception does not return early and still passes through `allowedHosts` validation.
- Authorization and token endpoint registered redirect-URI exact matching, PKCE, and `state` handling are unchanged.
- RFC 8252 primarily specifies loopback IP literals and dynamic ports. `localhost` is included as a Pi Adapter compatibility extension.

## Tests

- Targeted Vitest: 17 passed.
- Full backend suite: 204 passed.
- Lint, TypeScript type-checking (`tsc`), and Prettier checks passed.

Fixes #334
