### PR TITLE
fix: reap stdio worker descendants

### DIFF
--- a/apps/backend/src/lib/stdio-transport/process-managed-transport.test.ts
+++ b/apps/backend/src/lib/stdio-transport/process-managed-transport.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectDescendantPids,
+  parseProcStat,
+} from "./process-managed-transport";
+
+describe("parseProcStat", () => {
+  it("extracts pid and parent pid from Linux proc stat lines", () => {
+    expect(
+      parseProcStat("131 (uv tool uvx) S 56 131 131 0 -1 4194304"),
+    ).toEqual({
+      pid: 131,
+      ppid: 56,
+    });
+  });
+
+  it("handles process names containing closing parentheses", () => {
+    expect(parseProcStat("205 (worker) child) S 131 131 131 0")).toEqual({
+      pid: 205,
+      ppid: 131,
+    });
+  });
+
+  it("returns undefined for malformed stat lines", () => {
+    expect(parseProcStat("not a proc stat")).toBeUndefined();
+  });
+});
+
+describe("collectDescendantPids", () => {
+  it("returns every descendant below the root pid", () => {
+    expect(
+      collectDescendantPids(56, [
+        { pid: 1, ppid: 0 },
+        { pid: 56, ppid: 1 },
+        { pid: 131, ppid: 56 },
+        { pid: 205, ppid: 131 },
+        { pid: 209, ppid: 56 },
+        { pid: 216, ppid: 209 },
+        { pid: 999, ppid: 1 },
+      ]),
+    ).toEqual([205, 131, 216, 209]);
+  });
+
+  it("returns an empty list when the root has no children", () => {
+    expect(
+      collectDescendantPids(56, [
+        { pid: 1, ppid: 0 },
+        { pid: 56, ppid: 1 },
+        { pid: 999, ppid: 1 },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
+++ b/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, IOType } from "node:child_process";
+import fs from "node:fs/promises";
 import process from "node:process";
 import { PassThrough, Stream } from "node:stream";
 
@@ -9,6 +10,11 @@ import spawn from "cross-spawn";
 import logger from "@/utils/logger";
 
 import { ReadBuffer, serializeMessage } from "./shared";
+
+type ProcStat = {
+  pid: number;
+  ppid: number;
+};
 
 export type StdioServerParameters = {
   /**
@@ -267,6 +273,8 @@ export class ProcessManagedStdioTransport implements Transport {
     const pid = proc?.pid ?? null;
 
     if (pid && proc) {
+      const descendantPids = await listDescendantPids(pid);
+
       // Register the "close" listener BEFORE sending any signal so a fast-exiting
       // child cannot emit "close" in between and cause the promise to time out.
       const exitedPromise = new Promise<boolean>((resolve) => {
@@ -289,18 +297,26 @@ export class ProcessManagedStdioTransport implements Transport {
         );
       }
 
-      // Wait up to 5 seconds for graceful shutdown, then escalate to SIGKILL
-      const exited = await exitedPromise;
+      signalPids(descendantPids, "SIGTERM");
 
-      if (!exited) {
+      // Wait up to 5 seconds for graceful shutdown, then escalate to SIGKILL.
+      // The direct launcher may exit before its worker children are fully gone,
+      // so track the initial descendant set as well as the process-group close.
+      const [exited, remainingDescendants] = await Promise.all([
+        exitedPromise,
+        waitForProcessExit(descendantPids, 5000),
+      ]);
+
+      if (!exited || remainingDescendants.length > 0) {
         logger.warn(
-          `[transport.close] Process ${pid} still alive after 5s — sending SIGKILL`,
+          `[transport.close] Process ${pid} or descendants still alive after 5s — sending SIGKILL`,
         );
         try {
           process.kill(-pid, "SIGKILL");
         } catch {
           // Process may have already exited between the timeout check and the kill
         }
+        signalPids(remainingDescendants, "SIGKILL");
       }
     }
 
@@ -326,4 +342,131 @@ export class ProcessManagedStdioTransport implements Transport {
 
 function isElectron() {
   return "type" in process;
+}
+
+export function parseProcStat(stat: string): ProcStat | undefined {
+  const closeParen = stat.lastIndexOf(")");
+  if (closeParen === -1) {
+    return undefined;
+  }
+
+  const pid = Number.parseInt(stat.slice(0, stat.indexOf(" ")), 10);
+  const fieldsAfterCommand = stat
+    .slice(closeParen + 2)
+    .trim()
+    .split(/\s+/);
+  const ppid = Number.parseInt(fieldsAfterCommand[1] ?? "", 10);
+
+  if (!Number.isFinite(pid) || !Number.isFinite(ppid)) {
+    return undefined;
+  }
+
+  return { pid, ppid };
+}
+
+export function collectDescendantPids(
+  rootPid: number,
+  stats: Iterable<ProcStat>,
+): number[] {
+  const childrenByParent = new Map<number, number[]>();
+  for (const stat of stats) {
+    const children = childrenByParent.get(stat.ppid) ?? [];
+    children.push(stat.pid);
+    childrenByParent.set(stat.ppid, children);
+  }
+
+  const descendants: number[] = [];
+  const stack = [...(childrenByParent.get(rootPid) ?? [])];
+
+  while (stack.length > 0) {
+    const pid = stack.pop();
+    if (pid === undefined) {
+      continue;
+    }
+    descendants.push(pid);
+    stack.push(...(childrenByParent.get(pid) ?? []));
+  }
+
+  // Signal deepest descendants first so wrapper processes cannot abandon
+  // still-running workers while the tree is being torn down.
+  return descendants.reverse();
+}
+
+async function listDescendantPids(pid: number): Promise<number[]> {
+  if (process.platform !== "linux") {
+    return [];
+  }
+
+  try {
+    const entries = await fs.readdir("/proc", { withFileTypes: true });
+    const stats: ProcStat[] = [];
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) {
+          return;
+        }
+
+        try {
+          const stat = await fs.readFile(`/proc/${entry.name}/stat`, "utf8");
+          const parsed = parseProcStat(stat);
+          if (parsed) {
+            stats.push(parsed);
+          }
+        } catch {
+          // Processes can exit while /proc is being scanned.
+        }
+      }),
+    );
+
+    return collectDescendantPids(pid, stats);
+  } catch (error) {
+    logger.warn(
+      `[transport.close] Failed to scan descendant processes for ${pid}:`,
+      error,
+    );
+    return [];
+  }
+}
+
+function signalPids(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Process may already have exited.
+    }
+  }
+}
+
+async function waitForProcessExit(
+  pids: number[],
+  timeoutMs: number,
+): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs;
+  let remaining = pids.filter(isProcessAlive);
+
+  while (remaining.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    remaining = remaining.filter(isProcessAlive);
+  }
+
+  return remaining;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ESRCH"
+    ) {
+      return false;
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
## Summary
- scan Linux /proc for STDIO server descendant PIDs before transport shutdown
- signal tracked descendants alongside the spawned process group
- wait for launcher and worker descendants, then SIGKILL any remaining descendants
- add unit coverage for proc stat parsing and descendant collection

## Why
STDIO MCP servers are often started through wrappers such as uvx, npm exec, or shell launchers. The direct launcher process can exit or fail to reap children while worker processes remain alive, so MetaMCP can accumulate orphaned MCP workers and memory over time. This tightens ProcessManagedStdioTransport.close() so cleanup paths actually reap the worker tree.

This directly addresses the orphaned STDIO worker/process-tree leak in #162, and may reduce the blast radius of #272-style duplicate STDIO sessions by ensuring discarded sessions actually tear down their workers.

#324 is related but not fully fixed here: that issue is primarily about Streamable HTTP backend sessions being created repeatedly during tool-list refresh/hash checks and never closed. If those leaked sessions wrap STDIO servers this cleanup helps reap workers when the session is eventually cleaned up, but the tool-refresh session lifecycle likely still needs a separate follow-up.

Closes #162
Related to #272 and #324

## Testing
- npx vitest run src/lib/stdio-transport/process-managed-transport.test.ts src/lib/metamcp/session-error.test.ts src/lib/metamcp/list-handler-recovery.test.ts
- npx tsup
