### PR TITLE
fix(pool): don't treat "Method not found: ping" as a dead idle session

### DIFF
--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -1063,7 +1063,25 @@ export class McpServerPool {
       try {
         // Ping with a 5-second timeout
         await client.client.ping({ timeout: 5000 });
-      } catch {
+      } catch (error) {
+        // `ping` is OPTIONAL in the MCP spec, so a backend may legitimately not
+        // implement it and answer `-32601 Method not found`. That is a RESPONSE:
+        // it proves the connection is alive. Only silence (a timeout) or a
+        // transport failure means the session is dead.
+        //   "The Model Context Protocol includes an optional ping mechanism"
+        //   "Timeouts SHOULD be treated as connection failures"
+        //   -- spec 2025-11-25, basic/utilities/ping
+        // Without this guard the pool destroys and recreates a healthy idle
+        // connection every 60s, forever, for every server that lacks `ping`.
+        const pingError = error instanceof Error ? error.message : String(error);
+        const pingCode = (error as { code?: unknown })?.code;
+        if (
+          pingCode === -32601 ||
+          pingCode === "-32601" ||
+          pingError.includes("Method not found")
+        ) {
+          continue;
+        }
         logger.warn(
           `Idle session health check failed for server ${serverUuid}, recreating...`,
         );


### PR DESCRIPTION
`checkIdleSessionHealth()` pings each idle session inside a bare `catch {}`, so ANY exception counts as a dead connection — including the `-32601 Method not found` that a backend returns when it does not implement `ping`.

But `ping` is OPTIONAL in the spec, and an error response is still a RESPONSE: it proves the connection is alive. Per spec 2025-11-25, basic/utilities/ping:

  "The Model Context Protocol includes an optional ping mechanism"
  "Timeouts SHOULD be treated as connection failures"

So what should kill a session is SILENCE (a timeout) or a transport failure, not a well-formed error reply.

Observed on a 30-server deployment: the pool destroyed and recreated a perfectly healthy idle connection every 60 seconds, indefinitely (171+ cycles, exact cadence 15:48:36 / 15:49:36 / 15:50:36 ...). Only one server was affected — the only one that does not implement `ping`. It also produced a steady stream of `Per-server connection limit reached` warnings for that server, because each recreate competes for the same per-server slot budget.

The guard is deliberately narrow: only the JSON-RPC code -32601 and that exact message. A looser match such as `message.includes("ping")` would classify `timeout waiting for ping response` as healthy, which is precisely the failure this health check exists to catch.