### PR TITLE
fix(oauth): resolve client_id from Basic auth header (closes #342)

### DIFF
--- a/apps/backend/src/routers/oauth/token.ts
+++ b/apps/backend/src/routers/oauth/token.ts
@@ -34,6 +34,30 @@ async function issueTokenPair(clientId: string, userId: string, scope: string) {
 }
 
 /**
+ * Resolve the client_id for a token request.
+ *
+ * RFC 6749 2.3.1: a confidential client may authenticate with HTTP Basic, in
+ * which case client_id is in the Authorization header and NOT in the body.
+ * Clients registered with token_endpoint_auth_method=client_secret_basic send
+ * it that way, so reading req.body alone leaves client_id undefined for them.
+ *
+ * The body value takes precedence, so client_secret_post and public ("none")
+ * clients are unaffected.
+ */
+function resolveClientId(req: express.Request): string | undefined {
+  if (req.body?.client_id) return req.body.client_id;
+
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith("Basic ")) {
+    const decoded = Buffer.from(authHeader.substring(6), "base64").toString();
+    const separatorIndex = decoded.indexOf(":");
+    if (separatorIndex > 0) return decoded.substring(0, separatorIndex);
+  }
+
+  return undefined;
+}
+
+/**
  * OAuth 2.0 Token Endpoint
  * Handles token exchange requests from MCP clients
  * Supports authorization_code and refresh_token grant types
@@ -86,7 +110,8 @@ async function handleAuthorizationCodeGrant(
   req: express.Request,
   res: express.Response,
 ) {
-  const { code, redirect_uri, client_id, code_verifier } = req.body;
+  const { code, redirect_uri, code_verifier } = req.body;
+  const client_id = resolveClientId(req);
 
   // Validate authorization code
   if (!code) {
@@ -240,7 +265,8 @@ async function handleRefreshTokenGrant(
   req: express.Request,
   res: express.Response,
 ) {
-  const { refresh_token, client_id } = req.body;
+  const { refresh_token } = req.body;
+  const client_id = resolveClientId(req);
 
   if (!refresh_token) {
     return res.status(400).json({


### PR DESCRIPTION
Closes #342.

## Problem

`apps/backend/src/routers/oauth/token.ts` read `client_id` from the request body only:

```ts
const { code, redirect_uri, client_id, code_verifier } = req.body;  // authorization_code
const { refresh_token, client_id } = req.body;                      // refresh_token
```

RFC 6749 §2.3.1 places client credentials in the `Authorization: Basic` header for confidential clients, so for any client registered with `token_endpoint_auth_method: "client_secret_basic"` the value is `undefined`.

The two handlers then behave differently, and both are worth stating:

- **`handleAuthorizationCodeGrant`** — the guard `codeData.client_id !== client_id` is unconditional, so these clients are rejected `400 invalid_client` **every time**. The `client_secret_basic` branch further down does parse the header, but it sits below that guard and compares `authClientId !== client_id` against the same undefined body value, so it is unreachable for exactly the clients it exists to serve.
- **`handleRefreshTokenGrant`** — the guard is `client_id && tokenData.client_id !== client_id`, so a Basic client is not rejected; the client check is silently **skipped** instead. A weaker check rather than an outright failure, but the same root cause.

Real-world split: Google Gemini's custom connected apps register `client_secret_basic` and cannot connect at all, while Claude registers `client_secret_post` and works against the same endpoint. DCR accepts and issues a secret for `client_secret_basic`, so the method is supported on paper.

## Change

One helper plus its two call sites — no other edits.

`resolveClientId()` returns the body value when present, otherwise parses the Basic header. **Body-first is deliberate**: `client_secret_post` and public (`none`) clients take exactly the path they took before, so their behaviour is unchanged. The existing `client_secret_basic` secret-validation branch is untouched — it simply becomes reachable once `client_id` resolves.

## Known limitation, stated rather than hidden

RFC 6749 §2.3.1 specifies that credentials are `application/x-www-form-urlencoded`-encoded *before* base64, and this helper does not URL-decode after decoding base64. That is a no-op for MetaMCP's own generated client ids (`mcp_client_<base64url>`) and for the clients observed in practice, but a client id containing characters that require percent-encoding would not round-trip. Adding `decodeURIComponent` would handle it; I have left it out to keep the change minimal and because it is a behaviour question rather than a mechanical one. Happy to add it if you'd prefer.

## Testing

The repo runs vitest, but there are no tests under `apps/backend/src/routers/` — nothing currently covers `token.ts` — so I have not added one rather than stand up a router-test harness inside a bugfix PR. `resolveClientId` is a pure function and easy to unit test if you'd like it exported for that; say the word and I'll add it here.

Verified in production against a live instance: `client_secret_basic` clients that previously failed 100% now complete the token exchange, and `client_secret_post` clients are unaffected.
