### PR TITLE
perf(proxy): consolidated prewarm + never-spawn-unused + recovery + leak cleanup (backend-only)

### DIFF
--- a/apps/backend/src/db/repositories/mcp-servers.repo.ts
+++ b/apps/backend/src/db/repositories/mcp-servers.repo.ts
@@ -2,6 +2,7 @@ import {
   DatabaseMcpServer,
   McpServerCreateInput,
   McpServerErrorStatusEnum,
+  McpServerStatusEnum,
   McpServerUpdateInput,
 } from "@repo/zod-types";
 import { and, desc, eq, isNull, or } from "drizzle-orm";
@@ -11,7 +12,7 @@ import { z } from "zod";
 import logger from "@/utils/logger";
 
 import { db } from "../index";
-import { mcpServersTable } from "../schema";
+import { mcpServersTable, namespaceServerMappingsTable } from "../schema";
 
 // Helper function to handle PostgreSQL errors
 function handleDatabaseError(
@@ -83,6 +84,46 @@ export class McpServersRepository {
       .select()
       .from(mcpServersTable)
       .orderBy(desc(mcpServersTable.created_at));
+  }
+
+  /**
+   * Return only servers that have at least one ACTIVE namespace mapping.
+   * The startup idle-prewarm must not spawn servers the operator has turned
+   * off (status INACTIVE in namespace_server_mappings) — that matches how the
+   * tools/list path filters (getMcpServers includeInactiveServers=false).
+   */
+  async findActiveByMappings(): Promise<DatabaseMcpServer[]> {
+    return await db
+      .selectDistinctOn([mcpServersTable.uuid], {
+        uuid: mcpServersTable.uuid,
+        name: mcpServersTable.name,
+        description: mcpServersTable.description,
+        type: mcpServersTable.type,
+        command: mcpServersTable.command,
+        args: mcpServersTable.args,
+        env: mcpServersTable.env,
+        url: mcpServersTable.url,
+        error_status: mcpServersTable.error_status,
+        created_at: mcpServersTable.created_at,
+        bearerToken: mcpServersTable.bearerToken,
+        headers: mcpServersTable.headers,
+        forward_headers: mcpServersTable.forward_headers,
+        user_id: mcpServersTable.user_id,
+      })
+      .from(mcpServersTable)
+      .innerJoin(
+        namespaceServerMappingsTable,
+        eq(
+          namespaceServerMappingsTable.mcp_server_uuid,
+          mcpServersTable.uuid,
+        ),
+      )
+      .where(
+        eq(
+          namespaceServerMappingsTable.status,
+          McpServerStatusEnum.enum.ACTIVE,
+        ),
+      );
   }
 
   // Find servers accessible to a specific user (public + user's own servers)

--- a/apps/backend/src/db/repositories/tools.repo.ts
+++ b/apps/backend/src/db/repositories/tools.repo.ts
@@ -3,10 +3,14 @@ import {
   ToolCreateInput,
   ToolUpsertInput,
 } from "@repo/zod-types";
-import { and, eq, notInArray, sql } from "drizzle-orm";
+import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
 
 import { db } from "../index";
-import { toolsTable } from "../schema";
+import {
+  namespaceServerMappingsTable,
+  namespaceToolMappingsTable,
+  toolsTable,
+} from "../schema";
 
 export class ToolsRepository {
   async findByMcpServerUuid(mcpServerUuid: string): Promise<DatabaseTool[]> {
@@ -14,6 +18,58 @@ export class ToolsRepository {
       .select()
       .from(toolsTable)
       .where(eq(toolsTable.mcp_server_uuid, mcpServerUuid))
+      .orderBy(toolsTable.name);
+  }
+
+  /**
+   * Read the fully-scoped, override-aware tool list for a namespace in ONE
+   * indexed query — no backend I/O. This is the hot path for serve-from-DB.
+   *
+   * Returns tools joined through namespace_tool_mappings (scoped to the
+   * namespace, ACTIVE status, with override fields applied), restricted to
+   * servers currently ACTIVE in the namespace.
+   */
+  async readToolsForNamespace(
+    namespaceUuid: string,
+  ): Promise<Array<DatabaseTool & { namespace_status?: string }>> {
+    // Subquery: the ACTIVE servers for this namespace (from the namespace→server
+    // mappings), so we never surface tools from servers that were removed.
+    const activeServerUuids = db
+      .select({ uuid: namespaceServerMappingsTable.mcp_server_uuid })
+      .from(namespaceServerMappingsTable)
+      .where(
+        and(
+          eq(namespaceServerMappingsTable.namespace_uuid, namespaceUuid),
+          eq(namespaceServerMappingsTable.status, "ACTIVE"),
+        ),
+      );
+
+    return await db
+      .select({
+        uuid: toolsTable.uuid,
+        name: toolsTable.name,
+        description: toolsTable.description,
+        toolSchema: toolsTable.toolSchema,
+        created_at: toolsTable.created_at,
+        updated_at: toolsTable.updated_at,
+        mcp_server_uuid: toolsTable.mcp_server_uuid,
+        namespace_status: namespaceToolMappingsTable.status,
+      })
+      .from(toolsTable)
+      .innerJoin(
+        namespaceToolMappingsTable,
+        eq(namespaceToolMappingsTable.tool_uuid, toolsTable.uuid),
+      )
+      .where(
+        and(
+          eq(namespaceToolMappingsTable.namespace_uuid, namespaceUuid),
+          eq(namespaceToolMappingsTable.status, "ACTIVE"),
+          inArray(
+            toolsTable.mcp_server_uuid,
+            activeServerUuids,
+          ),
+        ),
+      )
       .orderBy(toolsTable.name);
   }
 

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -1,6 +1,17 @@
 import { ConfigKey, ConfigKeyEnum } from "@repo/zod-types";
 
+import logger from "@/utils/logger";
+
 import { configRepo } from "../db/repositories/config.repo";
+
+/**
+ * Default session lifetime in milliseconds (60 minutes).
+ *
+ * Kept finite so the pool's periodic `cleanupExpiredSessions` actually runs
+ * — a `null` default silently disabled cleanup and let active sessions
+ * accumulate until the connection cap was hit (the pool leak).
+ */
+export const DEFAULT_SESSION_LIFETIME_MS = 60 * 60 * 1000;
 
 export const configService = {
   async isSignupDisabled(): Promise<boolean> {
@@ -68,6 +79,24 @@ export const configService = {
     return config?.value ? parseInt(config.value, 10) : 60000;
   },
 
+  /**
+   * Resolve the MCP timeout for a namespace, honoring a per-namespace override
+   * (env MCP_TIMEOUT_<NAMESPACE_UPPER>_MS) before falling back to the global
+   * MCP_TIMEOUT. Lets a slow `shared` namespace carry a tighter budget than
+   * `general` so one slow backend can't hold others hostage.
+   */
+  async getMcpTimeoutForNamespace(namespaceName: string): Promise<number> {
+    if (namespaceName) {
+      const envKey = `MCP_TIMEOUT_${namespaceName.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_MS`;
+      const envVal = process.env[envKey];
+      if (envVal) {
+        const parsed = parseInt(envVal, 10);
+        if (!isNaN(parsed) && parsed > 0) return parsed;
+      }
+    }
+    return this.getMcpTimeout();
+  },
+
   async setMcpTimeout(timeout: number): Promise<void> {
     await configRepo.setConfig(
       ConfigKeyEnum.enum.MCP_TIMEOUT,
@@ -108,21 +137,44 @@ export const configService = {
     );
   },
 
+  /**
+   * Session lifetime in milliseconds before automatic cleanup, or null when
+   * explicitly configured as "infinite" (only via a database value).
+   *
+   * A null DEFAULT was the source of the pool connection leak: cleanup
+   * never ran, so active sessions accumulated forever and the pool hit the
+   * MAX_TOTAL_CONNECTIONS ceiling with no recovery path. The default is
+   * therefore a finite 60-minute lifetime; operators can still opt out with
+   * an explicit `SESSION_LIFETIME=null` in the database config.
+   */
   async getSessionLifetime(): Promise<number | null> {
     const config = await configRepo.getConfig(
       ConfigKeyEnum.enum.SESSION_LIFETIME,
     );
-    if (!config?.value) {
-      // Fallback to env var (milliseconds), then null (infinite sessions)
-      const envLifetime = process.env.SESSION_LIFETIME;
-      if (envLifetime) {
-        const parsed = parseInt(envLifetime, 10);
-        return isNaN(parsed) ? null : parsed;
+    if (config?.value) {
+      // Explicit database value is authoritative. `null` here is a valid
+      // operator opt-out (infinite sessions), not an accidental empty.
+      if (config.value === "null") {
+        return null;
       }
-      return null;
+      const lifetime = parseInt(config.value, 10);
+      if (isNaN(lifetime)) {
+        logger.warn(
+          `Invalid SESSION_LIFETIME config value "${config.value}" (expected milliseconds or "null"); falling back to default ${DEFAULT_SESSION_LIFETIME_MS}ms`,
+        );
+        return DEFAULT_SESSION_LIFETIME_MS;
+      }
+      return lifetime;
     }
-    const lifetime = parseInt(config.value, 10);
-    return isNaN(lifetime) ? null : lifetime;
+    // No database row: fall back to env var, then the finite default.
+    const envLifetime = process.env.SESSION_LIFETIME;
+    if (envLifetime && envLifetime !== "null") {
+      const parsed = parseInt(envLifetime, 10);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return DEFAULT_SESSION_LIFETIME_MS;
   },
 
   async setSessionLifetime(lifetime?: number | null): Promise<void> {

--- a/apps/backend/src/lib/metamcp/background-tools-sync.ts
+++ b/apps/backend/src/lib/metamcp/background-tools-sync.ts
@@ -1,0 +1,219 @@
+import { ServerParameters } from "@repo/zod-types";
+import { ListToolsResultSchema, Tool } from "@modelcontextprotocol/sdk/types.js";
+
+import logger from "@/utils/logger";
+
+import { toolsRepository } from "../../db/repositories";
+import { configService } from "../config.service";
+import { circuitBreaker } from "./circuit-breaker";
+import { getMcpServers } from "./fetch-metamcp";
+import { filterOutOverrideTools } from "./override-filter";
+import { toolsSyncCache } from "./tools-sync-cache";
+
+/**
+ * Background tools-sync loop + freshness tracker.
+ *
+ * Keeps the `tools` table fresh so `tools/list` can be served from the DB (the
+ * fast hot path) instead of fanning out to every backend. The loop runs off the
+ * request path entirely; a request that finds a stale/absent server calls
+ * `ensureFresh()` (debounced) to pull it in soon, but returns immediately from
+ * cached DB rows.
+ *
+ * Freshness model (per server):
+ *  - lastSyncedAt tracked in-memory.
+ *  - TTL default 60s (`MCP_TOOLS_TTL_MS`).
+ *  - "stale"  = now - lastSyncedAt > TTL   → serve last-known from DB + refresh in bg.
+ *  - "absent" = no tools rows for the server → one-off bounded fetch (fallback) in the
+ *               request path.
+ */
+
+const DEFAULT_TTL_MS = 60_000;
+
+class BackgroundToolsSync {
+  private loopTimer: NodeJS.Timeout | null = null;
+  private readonly syncIntervalMs: number;
+  private readonly ttlMs: number;
+  private readonly lastSyncedAt: Map<string, number> = new Map();
+  private readonly inFlight: Set<string> = new Set();
+
+  constructor(syncIntervalMs: number = 60_000) {
+    this.syncIntervalMs = syncIntervalMs;
+    this.ttlMs = parseInt(process.env.MCP_TOOLS_TTL_MS || `${DEFAULT_TTL_MS}`, 10);
+  }
+
+  /** Start the periodic loop (idempotent). */
+  start(): void {
+    if (this.loopTimer) return;
+    this.loopTimer = setInterval(() => {
+      this.loop().catch((error) => {
+        logger.error("[tools-sync] background loop error:", error);
+      });
+    }, this.syncIntervalMs);
+    // Unref so the loop doesn't keep the process alive on its own.
+    this.loopTimer.unref();
+  }
+
+  /** Stop the periodic loop. */
+  stop(): void {
+    if (this.loopTimer) {
+      clearInterval(this.loopTimer);
+      this.loopTimer = null;
+    }
+  }
+
+  /** True if the server's cached tools are still fresh. */
+  isFresh(serverUuid: string): boolean {
+    const last = this.lastSyncedAt.get(serverUuid);
+    if (last === undefined) return false;
+    return Date.now() - last < this.ttlMs;
+  }
+
+  /**
+   * Debounced single-server refresh. Called from the request path when a server
+   * is stale/absent. Non-blocking; returns immediately.
+   */
+  ensureFresh(serverUuid: string, params: ServerParameters, namespaceUuid: string): void {
+    if (this.inFlight.has(serverUuid)) return;
+    this.syncServer(serverUuid, params, namespaceUuid).catch((error) => {
+      logger.error(`[tools-sync] background refresh failed for ${serverUuid}:`, error);
+    });
+  }
+
+  /** One full pass over every namespace + ACTIVE server, syncing stale ones. */
+  private async loop(): Promise<void> {
+    const namespaces = await this.getAllNamespaces();
+    for (const ns of namespaces) {
+      try {
+        const serverParams = await getMcpServers(ns, false);
+        const entries = Object.entries(serverParams);
+        logger.info(
+          `[tools-sync] pass: namespace ${ns} has ${entries.length} active servers`,
+        );
+        await Promise.allSettled(
+          entries.map(async ([uuid, params]) => {
+            if (this.isFresh(uuid)) return;
+            // Skip tripped servers — don't hammer a backend the circuit
+            // breaker has opened.
+            if (circuitBreaker.isOpen(uuid)) return;
+            await this.syncServer(uuid, params, ns);
+          }),
+        );
+      } catch (error) {
+        logger.error(`[tools-sync] pass failed for namespace ${ns}:`, error);
+      }
+    }
+  }
+
+  /**
+   * Fetch + filter + sync ONE server's tools into the DB. Used by both the loop
+   * and the on-demand `ensureFresh`. Bounded by the configurable MCP timeout so a
+   * hung backend can't stall the loop.
+   */
+  private async syncServer(
+    serverUuid: string,
+    params: ServerParameters,
+    namespaceUuid: string,
+  ): Promise<void> {
+    if (this.inFlight.has(serverUuid)) return;
+    this.inFlight.add(serverUuid);
+    try {
+      const timeout = await configService.getMcpTimeoutForNamespace(namespaceUuid);
+      const tools = await this.fetchToolsForServer(params, timeout);
+      // Circuit breaker: a clean sync (tools fetched) is evidence the backend
+      // is healthy — clear any prior tripped state so a recovered server is
+      // synced again on the next pass.
+      circuitBreaker.onSuccess(serverUuid);
+      const toolNames = tools.map((t) => t.name);
+      const hasChanged = toolsSyncCache.hasChanged(serverUuid, toolNames);
+      // ALWAYS reap: syncTools runs deleteObsoleteTools every pass (the hash
+      // guard only skips the idempotent upsert when nothing changed) so removed
+      // backend tools converge in the DB instead of lingering as stale rows.
+      const toolsToSave = await filterOutOverrideTools(
+        tools,
+        namespaceUuid,
+        params.name,
+      );
+      if (toolsToSave.length > 0) {
+        toolsSyncCache.update(serverUuid, toolNames);
+        await toolsRepository.syncTools({
+          tools: toolsToSave,
+          mcpServerUuid: serverUuid,
+        });
+        logger.info(
+          `[tools-sync] synced ${toolsToSave.length} tools for ${params.name} (${serverUuid})${hasChanged ? "" : " (reap-only, unchanged)"}`,
+        );
+      }
+      this.lastSyncedAt.set(serverUuid, Date.now());
+    } catch (error) {
+      // Circuit breaker: a failed connect/sync counts toward tripping the
+      // server, so the loop stops hammering a cold/dead backend every pass
+      // and gives it a cooldown window to recover (MCP_BREAKER_*).
+      circuitBreaker.onFailure(serverUuid);
+      logger.warn(
+        `[tools-sync] sync failed for ${params.name} (${serverUuid}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    } finally {
+      this.inFlight.delete(serverUuid);
+    }
+  }
+
+  /** Bounded tools/list fetch against a single backend server. */
+  private async fetchToolsForServer(
+    params: ServerParameters,
+    timeout: number,
+  ): Promise<Tool[]> {
+    // Prefer a warm pooled connection (the pool holds idle sessions); fall back
+    // to a bounded one-off connect only if the pool has none available.
+    const { mcpServerPool } = await import("./mcp-server-pool");
+    const session = await mcpServerPool.getSession(
+      `tools-sync-${params.uuid}`,
+      params.uuid,
+      params,
+    );
+
+    if (session) {
+      try {
+        const result = await session.client.request(
+          { method: "tools/list", params: {} },
+          ListToolsResultSchema,
+          { timeout, resetTimeoutOnProgress: true },
+        );
+        return result.tools || [];
+      } finally {
+        // Return the connection to the pool (recycles back to idle).
+        await mcpServerPool.cleanupSession(`tools-sync-${params.uuid}`);
+      }
+    }
+
+    // Pool refused (at cap / error state) — one-off bounded connect.
+    const { connectMetaMcpClient } = await import("./client");
+    const connected = await connectMetaMcpClient(params);
+    if (!connected) {
+      throw new Error(
+        `[tools-sync] connect failed for ${params.name} (${params.uuid})`,
+      );
+    }
+    try {
+      const result = await connected.client.request(
+        { method: "tools/list", params: {} },
+        ListToolsResultSchema,
+        { timeout, resetTimeoutOnProgress: true },
+      );
+      return result.tools || [];
+    } finally {
+      await connected.cleanup();
+    }
+  }
+
+  /** All namespace UUIDs from the DB. */
+  private async getAllNamespaces(): Promise<string[]> {
+    const { namespacesRepository } = await import("../../db/repositories");
+    const namespaces = await namespacesRepository.findAll();
+    return namespaces.map((n) => n.uuid);
+  }
+}
+
+export const backgroundToolsSync = new BackgroundToolsSync();
+export type { ServerParameters };

--- a/apps/backend/src/lib/metamcp/call-tool-result-normalize.test.ts
+++ b/apps/backend/src/lib/metamcp/call-tool-result-normalize.test.ts
@@ -1,0 +1,94 @@
+import {
+  CallToolResult,
+  CallToolResultSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+
+import { normalizeCallToolResult } from "./call-tool-result";
+
+describe("normalizeCallToolResult", () => {
+  it("passes a well-formed CallToolResult through unchanged", () => {
+    const result: CallToolResult = {
+      content: [{ type: "text", text: "hello" }],
+    };
+    expect(normalizeCallToolResult(result, "server-1")).toBe(result);
+  });
+
+  it("coerces a non-conforming content block instead of hard-failing (-32602)", () => {
+    // The pocket-id case: content[0] is missing type/text.
+    const result = {
+      content: [{ foo: "bar" }],
+    } as unknown as CallToolResult;
+
+    const normalized = normalizeCallToolResult(result, "server-1");
+    expect(normalized.content).toHaveLength(1);
+    expect(normalized.content[0]).toMatchObject({
+      type: "text",
+      text: JSON.stringify({ foo: "bar" }),
+    });
+  });
+
+  it("coerces a bare string content block to a text block", () => {
+    const result = {
+      content: ["just a string"],
+    } as unknown as CallToolResult;
+
+    const normalized = normalizeCallToolResult(result, "server-1");
+    expect(normalized.content[0]).toMatchObject({
+      type: "text",
+      text: "just a string",
+    });
+  });
+
+  it("coerces non-array content to a single text block", () => {
+    const result = {
+      content: { message: "hello" },
+    } as unknown as CallToolResult;
+
+    const normalized = normalizeCallToolResult(result, "server-1");
+    expect(normalized.content).toHaveLength(1);
+    expect(normalized.content[0]).toMatchObject({
+      type: "text",
+      text: JSON.stringify({ message: "hello" }),
+    });
+  });
+
+  it("preserves conforming blocks and only coerces the malformed ones", () => {
+    const result = {
+      content: [
+        { type: "text", text: "ok" },
+        { type: "image", data: "abc", mimeType: "image/png" },
+        { missing: true },
+      ],
+    } as unknown as CallToolResult;
+
+    const normalized = normalizeCallToolResult(result, "server-1");
+    expect(normalized.content).toHaveLength(3);
+    expect(normalized.content[0]).toMatchObject({ type: "text", text: "ok" });
+    expect(normalized.content[1]).toMatchObject({ type: "image" });
+    expect(normalized.content[2]).toMatchObject({
+      type: "text",
+      text: JSON.stringify({ missing: true }),
+    });
+  });
+
+  it("returns a valid empty result when content is undefined", () => {
+    const result = { content: undefined } as unknown as CallToolResult;
+    const normalized = normalizeCallToolResult(result, "server-1");
+    expect(normalized.content).toHaveLength(1);
+    expect(normalized.content[0]).toMatchObject({ type: "text", text: "" });
+  });
+
+  it("the normalized result passes CallToolResultSchema (no -32602 after normalization)", () => {
+    // The pocket-id case: content[0] is { foo: "bar" } — a raw backend result
+    // that hard-fails the SDK schema with -32602 if not normalized first.
+    const raw = {
+      content: [{ foo: "bar" }],
+    } as unknown as CallToolResult;
+
+    const normalized = normalizeCallToolResult(raw, "server-1");
+    // This is the exact check the proxy now runs after normalizing; a raw
+    // backend result would have failed here.
+    expect(CallToolResultSchema.safeParse(normalized).success).toBe(true);
+  });
+});

--- a/apps/backend/src/lib/metamcp/call-tool-result.ts
+++ b/apps/backend/src/lib/metamcp/call-tool-result.ts
@@ -1,0 +1,102 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import logger from "@/utils/logger";
+
+/**
+ * True if a content block is already a valid SDK content block. Accepts any of
+ * the SDK's known block shapes (text has `text`, image has `data`+`mimeType`,
+ * resource has `resource`, audio has `data`+`mimeType`); a block that is not an
+ * object with a string `type` and its type's required fields is malformed.
+ */
+function isConformingContentBlock(
+  block: CallToolResult["content"][number] | null | undefined | object | string,
+): block is CallToolResult["content"][number] {
+  if (typeof block !== "object" || block === null) {
+    return false;
+  }
+  const b = block as Record<string, unknown>;
+  if (typeof b.type !== "string") {
+    return false;
+  }
+  switch (b.type) {
+    case "text":
+      return typeof b.text === "string";
+    case "image":
+    case "audio":
+      return typeof b.data === "string" && typeof b.mimeType === "string";
+    case "resource":
+      return typeof b.resource === "object" && b.resource !== null;
+    default:
+      // Unknown block type — treat as malformed and coerce to text.
+      return false;
+  }
+}
+
+/**
+ * Coerce a backend's `CallToolResult` into the SDK shape the MCP client
+ * expects. Some backends return a non-conforming `content` (e.g.
+ * `[{ foo: "bar" }]` without `type`/`text`, or a bare string) which would
+ * otherwise hard-fail the zod validation with `-32602`. A backend's malformed
+ * output must never become a client-facing error — we normalize it instead and
+ * log the malformed shape for the operator.
+ */
+export function normalizeCallToolResult(
+  result: CallToolResult,
+  serverUuid: string,
+): CallToolResult {
+  const content = result.content;
+
+  if (!Array.isArray(content)) {
+    if (content !== undefined && content !== null) {
+      logger.warn(
+        `[call-tool] backend ${serverUuid} returned non-array CallToolResult content; coercing to text (${typeof content})`,
+      );
+    }
+    return {
+      ...result,
+      content: [
+        {
+          type: "text",
+          text:
+            content === undefined || content === null
+              ? ""
+              : typeof content === "string"
+                ? content
+                : JSON.stringify(content),
+        },
+      ],
+    };
+  }
+
+  const needsCoercion = content.some((block) => !isConformingContentBlock(block));
+
+  if (!needsCoercion) {
+    return result;
+  }
+
+  logger.warn(
+    `[call-tool] backend ${serverUuid} returned malformed CallToolResult content; coercing non-conforming blocks to text`,
+  );
+
+  return {
+    ...result,
+    content: content.map((block) => {
+      const unknownBlock = block as Record<string, unknown> | null;
+      if (isConformingContentBlock(block)) {
+        return block;
+      }
+      // Coerce a non-conforming block to a text block. Preserve known fields
+      // when available; a bare string becomes its own text block.
+      if (typeof block === "string") {
+        return { type: "text", text: block };
+      }
+      const text =
+        unknownBlock === null
+          ? ""
+          : typeof unknownBlock?.text === "string"
+            ? unknownBlock.text
+            : JSON.stringify(unknownBlock);
+      return { type: "text", text };
+    }),
+  };
+}

--- a/apps/backend/src/lib/metamcp/circuit-breaker.ts
+++ b/apps/backend/src/lib/metamcp/circuit-breaker.ts
@@ -1,0 +1,93 @@
+import logger from "@/utils/logger";
+
+/**
+ * Per-backend circuit breaker.
+ *
+ * If a backend MCP server times out N times in a row, it is "tripped" and
+ * excluded from tool aggregation for a cooldown window (so the sync loop and
+ * tools/list don't keep hammering a dead/slow backend). After the cooldown it
+ * transitions to "half-open": one probe request is allowed; if it succeeds the
+ * breaker resets, if it fails it re-trips for another window.
+ *
+ * Keyed by server UUID. In-memory only (resets on restart, which is fine — a
+ * restart clears error state anyway).
+ */
+
+interface BreakerState {
+  consecutiveFailures: number;
+  trippedUntil: number | null; // epoch ms while OPEN
+  halfOpenProbe: boolean; // a probe is in-flight while HALF_OPEN
+}
+
+const DEFAULT_FAIL_THRESHOLD = 3;
+const DEFAULT_COOLDOWN_MS = 30_000;
+
+class CircuitBreaker {
+  private readonly states: Map<string, BreakerState> = new Map();
+  private readonly failThreshold: number;
+  private readonly cooldownMs: number;
+
+  constructor(
+    failThreshold: number = parseInt(
+      process.env.MCP_BREAKER_FAIL_THRESHOLD || `${DEFAULT_FAIL_THRESHOLD}`,
+      10,
+    ),
+    cooldownMs: number = parseInt(
+      process.env.MCP_BREAKER_COOLDOWN_MS || `${DEFAULT_COOLDOWN_MS}`,
+      10,
+    ),
+  ) {
+    this.failThreshold = failThreshold;
+    this.cooldownMs = cooldownMs;
+  }
+
+  private state(serverUuid: string): BreakerState {
+    let s = this.states.get(serverUuid);
+    if (!s) {
+      s = { consecutiveFailures: 0, trippedUntil: null, halfOpenProbe: false };
+      this.states.set(serverUuid, s);
+    }
+    return s;
+  }
+
+  /** Should we avoid initiating work against this server right now? */
+  isOpen(serverUuid: string): boolean {
+    const s = this.state(serverUuid);
+    if (s.trippedUntil === null) return false;
+    if (Date.now() < s.trippedUntil) return true;
+    // Cooldown elapsed → HALF_OPEN: allow a probe (the first request through).
+    return false;
+  }
+
+  /** Mark a successful request against the server — reset the breaker. */
+  onSuccess(serverUuid: string): void {
+    const s = this.state(serverUuid);
+    s.consecutiveFailures = 0;
+    s.trippedUntil = null;
+    s.halfOpenProbe = false;
+  }
+
+  /** Mark a timed-out / failed request — count toward tripping. */
+  onFailure(serverUuid: string): void {
+    const s = this.state(serverUuid);
+    s.consecutiveFailures += 1;
+    if (s.consecutiveFailures >= this.failThreshold) {
+      s.trippedUntil = Date.now() + this.cooldownMs;
+      s.halfOpenProbe = false;
+      logger.warn(
+        `[circuit-breaker] server ${serverUuid} tripped for ${this.cooldownMs}ms after ${s.consecutiveFailures} consecutive failures`,
+      );
+    }
+  }
+
+  /** Clear the breaker for a server (e.g. on manual recovery). */
+  reset(serverUuid: string): void {
+    this.states.delete(serverUuid);
+  }
+
+  getState(serverUuid: string): BreakerState | undefined {
+    return this.states.get(serverUuid);
+  }
+}
+
+export const circuitBreaker = new CircuitBreaker();

--- a/apps/backend/src/lib/metamcp/client.ts
+++ b/apps/backend/src/lib/metamcp/client.ts
@@ -19,10 +19,83 @@ import { resolveEnvVariables } from "./utils";
 const sleep = (time: number) =>
   new Promise<void>((resolve) => setTimeout(() => resolve(), time));
 
+/**
+ * Run `client.connect(transport)` under a timeout.
+ *
+ * The MCP SDK's request-timeout for the initialize handshake is not exposed
+ * as a Client option in the installed version, so this wraps the connect in
+ * a race. On timeout the transport is closed to release the spawned process,
+ * and the thrown error (with a descriptive message) flows into the caller's
+ * retry loop.
+ *
+ * stdio transports get a longer default (120s, MCP_STDIO_CONNECT_TIMEOUT_MS)
+ * because a cold spawn may have to download its package on first boot; HTTP
+ * transports keep the tighter default (90s, MCP_CONNECT_TIMEOUT_MS).
+ */
+async function connectWithTimeout(
+  client: Client,
+  transport: Transport,
+  serverType: string | undefined,
+): Promise<void> {
+  const isStdio = !serverType || serverType === "STDIO";
+  const timeoutMs = parseInt(
+    process.env[
+      isStdio ? "MCP_STDIO_CONNECT_TIMEOUT_MS" : "MCP_CONNECT_TIMEOUT_MS"
+    ] || (isStdio ? "120000" : "90000"),
+    10,
+  );
+  const timeoutEnv = isStdio
+    ? "MCP_STDIO_CONNECT_TIMEOUT_MS"
+    : "MCP_CONNECT_TIMEOUT_MS";
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  let timedOut = false;
+
+  try {
+    await Promise.race([
+      client.connect(transport),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          reject(
+            new Error(
+              `MCP connect timed out after ${timeoutMs}ms (${timeoutEnv})`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    if (timedOut) {
+      // Release the child process so a timed-out cold spawn does not linger.
+      try {
+        await transport.close();
+      } catch (cleanupError) {
+        logger.error(
+          "Error closing transport after connect timeout:",
+          cleanupError,
+        );
+      }
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 export interface ConnectedClient {
   client: Client;
   cleanup: () => Promise<void>;
   onProcessCrash?: (exitCode: number | null, signal: string | null) => void;
+  /**
+   * Last-touch timestamp (ms epoch), maintained by the server pool. Drives
+   * the LRU idle/active eviction (capacity recovery) and the per-server
+   * idle timeout. The pool sets it on creation, on idle→active reuse, on
+   * getSession access, and on recycle; callers must not rely on it.
+   */
+  lastUsedAt?: number;
 }
 
 /**
@@ -166,8 +239,6 @@ export const connectMetaMcpClient = async (
   serverParams: ServerParameters,
   onProcessCrash?: (exitCode: number | null, signal: string | null) => void,
 ): Promise<ConnectedClient | undefined> => {
-  const waitFor = 5000;
-
   // Get max attempts from server error tracker instead of hardcoding
   const maxAttempts = await serverErrorTracker.getServerMaxAttempts(
     serverParams.uuid,
@@ -243,7 +314,14 @@ export const connectMetaMcpClient = async (
         };
       }
 
-      await client.connect(transport);
+      // Connect-timeout envelope. The SDK's initialize-handshake timeout is
+      // not directly configurable in this version, and cold-start spawns
+      // (uvx/npx/bunx boots, especially under the bounded spawn-concurrency
+      // gate) can exceed the 60s default. Race connect() against a generous,
+      // transport-appropriate timeout (stdio: MCP_STDIO_CONNECT_TIMEOUT_MS,
+      // HTTP: MCP_CONNECT_TIMEOUT_MS) so a slow cold server fails into the
+      // outer retry loop instead of hanging the fan-out.
+      await connectWithTimeout(client, transport, serverParams.type);
       metamcpLogStore.addLog(
         serverParams.name,
         "info",
@@ -456,7 +534,16 @@ export const connectMetaMcpClient = async (
       count++;
       retry = count < maxAttempts;
       if (retry) {
-        await sleep(waitFor);
+        // Exponential backoff with jitter: base 5s, doubling to a 60s cap,
+        // ±20% jitter so concurrent retries don't line up in lockstep (the
+        // old fixed 5s sleep hammered a recovering backend in a tight loop).
+        const base = Math.min(5000 * 2 ** (count - 1), 60000);
+        const jitter = 0.8 + Math.random() * 0.4; // 0.8x – 1.2x
+        const delay = Math.round(base * jitter);
+        logger.info(
+          `Retrying connection to ${serverParams.name} (${serverParams.uuid}) in ${delay}ms (attempt ${count}/${maxAttempts})`,
+        );
+        await sleep(delay);
       }
     }
   }

--- a/apps/backend/src/lib/metamcp/list-handler-recovery.test.ts
+++ b/apps/backend/src/lib/metamcp/list-handler-recovery.test.ts
@@ -1,10 +1,12 @@
 import { ServerParameters } from "@repo/zod-types";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { circuitBreaker } from "./circuit-breaker";
 import { ConnectedClient } from "./client";
 import {
   RecoverySessionPool,
   requestWithSessionRecovery,
+  resetRecoveryCooldowns,
 } from "./list-handler-recovery";
 
 // The exact envelope shape the backend produces when its session died
@@ -42,6 +44,12 @@ const baseOpts = (pool: RecoverySessionPool, session: ConnectedClient) => ({
 });
 
 describe("requestWithSessionRecovery", () => {
+  afterEach(() => {
+    circuitBreaker.reset("server-1");
+    resetRecoveryCooldowns();
+    vi.useRealTimers();
+  });
+
   it("returns the first attempt's result without touching the pool", async () => {
     const session = makeSession("stale");
     const pool = makePool(undefined);
@@ -146,5 +154,48 @@ describe("requestWithSessionRecovery", () => {
       requestWithSessionRecovery({ ...baseOpts(pool, stale), attempt }),
     ).rejects.toBe(secondFailure);
     expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the reconnect entirely when the circuit breaker is open", async () => {
+    const stale = makeSession("stale");
+    const pool = makePool(undefined);
+    const attempt = vi.fn().mockRejectedValue(sessionLostError());
+    circuitBreaker.onFailure("server-1");
+    circuitBreaker.onFailure("server-1");
+    circuitBreaker.onFailure("server-1"); // tripped (threshold 3)
+
+    await expect(
+      requestWithSessionRecovery({ ...baseOpts(pool, stale), attempt }),
+    ).rejects.toThrow(/circuit-open/);
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(pool.invalidateServerConnection).not.toHaveBeenCalled();
+    expect(pool.getSession).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits repeated recoveries for the same server within the cooldown window", async () => {
+    const stale = makeSession("stale");
+    const fresh = makeSession("fresh");
+    const pool = makePool(fresh);
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(sessionLostError())
+      .mockResolvedValueOnce("ok");
+
+    // First recovery succeeds.
+    await expect(
+      requestWithSessionRecovery({ ...baseOpts(pool, stale), attempt }),
+    ).resolves.toBe("ok");
+
+    // A second recovery for the same server within the cooldown is refused —
+    // the retry-able backend must not be invalidated + re-spawned repeatedly.
+    const secondAttempt = vi.fn().mockRejectedValue(sessionLostError());
+    await expect(
+      requestWithSessionRecovery({
+        ...baseOpts(pool, stale),
+        attempt: secondAttempt,
+      }),
+    ).rejects.toThrow(/recovered within the last/);
+    expect(pool.getSession).toHaveBeenCalledTimes(1);
+    expect(secondAttempt).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/backend/src/lib/metamcp/list-handler-recovery.ts
+++ b/apps/backend/src/lib/metamcp/list-handler-recovery.ts
@@ -2,8 +2,35 @@ import { ServerParameters } from "@repo/zod-types";
 
 import logger from "@/utils/logger";
 
+import { circuitBreaker } from "./circuit-breaker";
 import { ConnectedClient } from "./client";
 import { isRecoverableBackendError } from "./session-error";
+
+/**
+ * Cooldown between recoveries for the same server. Prevents a backend that
+ * keeps reporting session-lost from being invalidated + re-spawned on every
+ * request in a tight loop — the "hang" where each call spawns a fresh process
+ * that is also unhealthy, until the client's deadline. A server is recovered
+ * at most once per window; a request that hits the cooldown surfaces a clean
+ * retryable error instead of blocking on another spawn.
+ */
+const RECOVERY_COOLDOWN_MS = parseInt(
+  process.env.MCP_RECOVERY_COOLDOWN_MS || "10000",
+  10,
+);
+
+/** Last recovery time per serverUuid (in-memory). */
+const lastRecoveredAt = new Map<string, number>();
+
+function isRecoveryCooldownActive(serverUuid: string): boolean {
+  const last = lastRecoveredAt.get(serverUuid);
+  return last !== undefined && Date.now() - last < RECOVERY_COOLDOWN_MS;
+}
+
+/** Reset the recovery cooldown map (test isolation). */
+export function resetRecoveryCooldowns(): void {
+  lastRecoveredAt.clear();
+}
 
 /**
  * Minimal slice of McpServerPool the recovery wrapper needs. Structural
@@ -73,6 +100,25 @@ export async function requestWithSessionRecovery<T>(
       throw error;
     }
 
+    // Circuit breaker: a tripped server must not be spawned into repeatedly.
+    // Surface a clean recoverable-exit error instead; the caller marks the
+    // server degraded/pending and the breaker's half-open probe lets a real
+    // request through once the cooldown elapses.
+    if (circuitBreaker.isOpen(opts.serverUuid)) {
+      throw new Error(
+        `Server ${opts.serverUuid} (${opts.serverName}) is circuit-open; skipping reconnect during ${opts.operation}`,
+      );
+    }
+
+    // Recovery rate-limit: at most one invalidate+re-spawn per window per
+    // server. Without it a backend that keeps reporting session-lost spawns
+    // a fresh unhealthy process on every request — the endless hang.
+    if (isRecoveryCooldownActive(opts.serverUuid)) {
+      throw new Error(
+        `Server ${opts.serverUuid} (${opts.serverName}) recovered within the last ${RECOVERY_COOLDOWN_MS}ms; skipping reconnect during ${opts.operation}`,
+      );
+    }
+
     logger.warn(
       `Backend connection lost for server ${opts.serverUuid} (${opts.serverName}) on ${opts.operation}; invalidating pool and retrying once. (envelope: ${
         error instanceof Error ? error.message : String(error)
@@ -80,6 +126,7 @@ export async function requestWithSessionRecovery<T>(
     );
 
     await opts.pool.invalidateServerConnection(opts.sessionId, opts.serverUuid);
+    lastRecoveredAt.set(opts.serverUuid, Date.now());
 
     const fresh = await opts.pool.getSession(
       opts.sessionId,

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -15,6 +15,25 @@ export interface McpServerPoolStatus {
   idleServerUuids: string[];
   perServerCounts?: Record<string, number>;
   maxConnectionsPerServer?: number;
+  lastEvictedAt?: number | null;
+  evictionCount?: number;
+}
+
+export interface McpServerPoolDebugInfo {
+  idle: number;
+  active: number;
+  pending: number;
+  evicted: number;
+  lastEvictedAt: number | null;
+  total: number;
+  maxTotalConnections: number;
+  maxConnectionsPerServer: number;
+  spawnConcurrency: number;
+  idleTimeoutMs: number;
+  sessionLifetimeMs: number | null;
+  activeSessionIds: string[];
+  idleServerUuids: string[];
+  perServerCounts: Record<string, number>;
 }
 
 export class McpServerPool {
@@ -63,17 +82,102 @@ export class McpServerPool {
   // Maximum connections per individual server UUID (prevents per-server process explosion)
   private readonly maxConnectionsPerServer: number;
 
+  // Connection eviction accounting (drives the diagnostics log + status).
+  private lastEvictedAt: number | null = null;
+  private evictionCount = 0;
+
+  // Per-server idle timeout (ms). Idle sessions idle for longer than this are
+  // cleaned up by checkIdleSessionHealth (the 60s health loop), preventing a
+  // parked session from holding a process forever.
+  private readonly idleTimeoutMs: number;
+
+  // Health-loop recreate guard (see constructor). A failed health ping only
+  // recreates the idle session if the session hasn't served a request within
+  // the cooldown window AND has failed the ping this many consecutive times.
+  private readonly healthCheckRecreateCooldownMs: number;
+  private readonly healthCheckRecreateThreshold: number;
+  private readonly healthCheckFailures: Map<string, number>;
+  private readonly healthCheckTimeoutMs: number;
+  private readonly idleHealthPingEnabled: boolean;
+
+  // Spawn concurrency gate for cold-start: cap how many cold server processes
+  // may be connecting at once. Without it ensureIdleSessions() fires ~22
+  // simultaneous spawns that blow past the SDK connect timeout (the
+  // -32001/-32000 storm). Bounded spawns let each process get a fair share of
+  // CPU while it boots.
+  private spawnConcurrency = 0;
+  private readonly maxSpawnConcurrency: number;
+
+  // Maximum connections per namespace UUID (prevents a busy namespace from
+  // starving others). 0 = unlimited (default).
+  private readonly maxConnectionsPerNamespace: number;
+
+  // Live connection count per namespace UUID (idle + active + pending).
+  private readonly namespaceConnections: Map<string, number> = new Map();
+
+  // sessionId -> namespaceUuid, so cleanupSession can decrement the per-namespace
+  // count when a connection is destroyed (not recycled).
+  private readonly sessionNamespaces: Map<string, string> = new Map();
+
+  // Last time each server UUID logged an at-cap condition, for the 30s-per-server
+  // throttle on the cap warning.
+  private lastCapLogAt: Record<string, number> = {};
+
   private constructor(
     defaultIdleCount: number = 1,
     maxTotalConnections: number = parseInt(
       process.env.MAX_TOTAL_CONNECTIONS || "100",
       10,
     ),
-    maxConnectionsPerServer: number = 5,
+    maxConnectionsPerServer: number = parseInt(
+      process.env.MAX_CONNECTIONS_PER_SERVER || "5",
+      10,
+    ),
+    maxConnectionsPerNamespace: number = parseInt(
+      process.env.MAX_CONNECTIONS_PER_NAMESPACE || "0",
+      10,
+    ),
   ) {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;
     this.maxConnectionsPerServer = maxConnectionsPerServer;
+    this.idleTimeoutMs = parseInt(
+      process.env.MCP_IDLE_TIMEOUT_MS || `${30 * 60 * 1000}`,
+      10,
+    );
+    this.maxSpawnConcurrency = parseInt(
+      process.env.MCP_SPAWN_CONCURRENCY || "4",
+      10,
+    );
+    // Recreate cooldown for the idle health loop: a session must be untouched
+    // for this long before a failed ping justifies replacing it. Prevents the
+    // health check from recreating a session mid-flight / false-negatively.
+    this.healthCheckRecreateCooldownMs = parseInt(
+      process.env.MCP_HEALTH_RECREATE_COOLDOWN_MS || `${30 * 1000}`,
+      10,
+    );
+    // Consecutive recreate guard: a server must fail the health ping this many
+    // consecutive times before we recreate its idle session. A single flaky
+    // ping (slow backend boot, gc pause) must not trigger a spawn.
+    this.healthCheckRecreateThreshold = parseInt(
+      process.env.MCP_HEALTH_RECREATE_THRESHOLD || "2",
+      10,
+    );
+    // Eager idle-health ping. Default OFF — with lazy spawn-on-demand the
+    // health loop's job is recycling idle-past-timeout sessions, not keeping
+    // the pool warm; a dead session is caught by the recovery retry on the
+    // next real call, not by a 60s timer. Set MCP_IDLE_HEALTH_PING=1 to keep
+    // the old behavior.
+    this.idleHealthPingEnabled =
+      (process.env.MCP_IDLE_HEALTH_PING || "0").trim().toLowerCase() === "1";
+    this.healthCheckTimeoutMs = parseInt(
+      process.env.MCP_HEALTH_CHECK_TIMEOUT_MS || "5000",
+      10,
+    );
+    // Consecutive ping failures per server (reset on a successful ping or a
+    // recreate). Drives the threshold above.
+    this.healthCheckFailures = new Map();
+    this.maxConnectionsPerNamespace = maxConnectionsPerNamespace;
     this.startCleanupTimer();
     this.startHealthCheckTimer();
   }
@@ -83,7 +187,10 @@ export class McpServerPool {
    */
   static getInstance(
     defaultIdleCount: number = 1,
-    maxConnectionsPerServer: number = 5,
+    maxConnectionsPerServer: number = parseInt(
+      process.env.MAX_CONNECTIONS_PER_SERVER || "5",
+      10,
+    ),
   ): McpServerPool {
     if (!McpServerPool.instance) {
       const envMax = parseInt(process.env.MAX_TOTAL_CONNECTIONS || "", 10);
@@ -92,6 +199,7 @@ export class McpServerPool {
         defaultIdleCount,
         maxConn,
         maxConnectionsPerServer,
+        parseInt(process.env.MAX_CONNECTIONS_PER_NAMESPACE || "0", 10),
       );
     }
     return McpServerPool.instance;
@@ -129,12 +237,180 @@ export class McpServerPool {
   private canCreateConnectionForServer(serverUuid: string): boolean {
     const count = this.countConnectionsForServer(serverUuid);
     if (count >= this.maxConnectionsPerServer) {
-      logger.warn(
-        `Per-server connection limit reached for ${serverUuid}: ${count}/${this.maxConnectionsPerServer}`,
-      );
+      // Quiet: throttle the at-cap warning to once per 30s per server so a
+      // busy server doesn't flood the log (the pool reuses the oldest active
+      // connection at cap anyway).
+      const now = Date.now();
+      if ((this.lastCapLogAt[serverUuid] ?? 0) < now - 30_000) {
+        this.lastCapLogAt[serverUuid] = now;
+        logger.warn(
+          `Per-server connection limit reached for ${serverUuid}: ${count}/${this.maxConnectionsPerServer}`,
+        );
+      }
       return false;
     }
     return true;
+  }
+
+  /**
+   * Record a connection eviction for the diagnostics log / status.
+   */
+  private recordEviction(): void {
+    this.lastEvictedAt = Date.now();
+    this.evictionCount += 1;
+  }
+
+  /**
+   * Find the idle session with the oldest last-touch timestamp. Only returns
+   * one that actually predates `before` — a freshly-created idle session is
+   * not a valid eviction victim.
+   */
+  private findIdleEvictionVictim(before: number): ConnectedClient | undefined {
+    let victim: ConnectedClient | undefined;
+    let oldest: number | null = null;
+
+    for (const client of Object.values(this.idleSessions)) {
+      if (!client.lastUsedAt || client.lastUsedAt >= before) {
+        continue;
+      }
+      if (oldest === null || client.lastUsedAt < oldest) {
+        oldest = client.lastUsedAt;
+        victim = client;
+      }
+    }
+    return victim;
+  }
+
+  /**
+   * Evict an idle connection for a server UUID, freeing one connection slot.
+   *
+   * Idle sessions are capped at ONE per server UUID (see getSession idle
+   * reuse + cleanupSession recycling), so a per-server eviction must be able
+   * to drop a *different* server's idle session. Called with the timestamp
+   * captured when the eviction decision was made so a concurrently-created
+   * idle session (which has no lastUsedAt yet) is never picked as a victim.
+   */
+  private async evictOldestIdle(before: number): Promise<boolean> {
+    const victim = this.findIdleEvictionVictim(before);
+    if (!victim) {
+      return false;
+    }
+
+    // Remove from the idle map regardless of cleanup success.
+    for (const [serverUuid, client] of Object.entries(this.idleSessions)) {
+      if (client === victim) {
+        delete this.idleSessions[serverUuid];
+        break;
+      }
+    }
+    this.recordEviction();
+    logger.warn(
+      `Evicted oldest idle MCP connection (concurrency slot exhausted; connection count ${this.getTotalConnectionCount()}/${this.maxTotalConnections})`,
+    );
+
+    try {
+      await victim.cleanup();
+    } catch (error) {
+      logger.error("Error cleaning up evicted idle connection:", error);
+    }
+    return true;
+  }
+
+  /**
+   * Evict the LRU active connection for a server UUID (the session slot with
+   * the oldest last-touch), freeing one connection slot so a mid-flight
+   * server gets one. The evicted server's remaining active slots are removed
+   * from the request session; a subsequent getSession for that server
+   * re-establishes a connection on demand.
+   */
+  private async evictOldestActiveConnectionForServer(
+    serverUuid: string,
+  ): Promise<boolean> {
+    let oldestSessionId: string | undefined;
+    let oldestTimestamp = Infinity;
+
+    for (const [sessionId, sessionServers] of Object.entries(
+      this.activeSessions,
+    )) {
+      const cached = sessionServers[serverUuid];
+      if (!cached) {
+        continue;
+      }
+      const timestamp =
+        cached.lastUsedAt || this.sessionTimestamps[sessionId] || 0;
+      if (timestamp < oldestTimestamp) {
+        oldestTimestamp = timestamp;
+        oldestSessionId = sessionId;
+      }
+    }
+
+    if (!oldestSessionId) {
+      return false;
+    }
+
+    const victim = this.activeSessions[oldestSessionId]?.[serverUuid];
+    if (!victim) {
+      return false;
+    }
+    delete this.activeSessions[oldestSessionId][serverUuid];
+    this.sessionToServers[oldestSessionId]?.delete(serverUuid);
+
+    // Clean up empty session slots so they stop counting toward the active
+    // total (the leak) and get dropped from the session map.
+    if (Object.keys(this.activeSessions[oldestSessionId]).length === 0) {
+      delete this.activeSessions[oldestSessionId];
+      delete this.sessionToServers[oldestSessionId];
+      delete this.sessionTimestamps[oldestSessionId];
+    }
+
+    this.recordEviction();
+    logger.warn(
+      `Evicted LRU active MCP connection for server ${serverUuid} (session ${oldestSessionId}); slot freed for a mid-flight server`,
+    );
+
+    try {
+      await victim.cleanup();
+    } catch (error) {
+      logger.error(
+        `Error cleaning up evicted active connection for ${serverUuid}:`,
+        error,
+      );
+    }
+    return true;
+  }
+
+  /**
+   * Acquire a spawn-concurrency slot. Bounds how many cold server processes
+   * may be connecting at once so a cold start doesn't blow past the SDK
+   * connect timeout with ~22 simultaneous spawns.
+   */
+  private acquireSpawnSlot(before: number): Promise<() => void> {
+    return new Promise((resolve) => {
+      const attempt = (): void => {
+        if (this.spawnConcurrency < this.maxSpawnConcurrency) {
+          this.spawnConcurrency += 1;
+          resolve(() => {
+            this.spawnConcurrency -= 1;
+          });
+          return;
+        }
+        // Slot full. If the pool is at the hard cap, evict the oldest idle
+        // connection to make room for the cold start (a cold start must not
+        // be able to strand the pool at the cap forever). Either way, defer
+        // the retry through setTimeout so the event loop stays responsive —
+        // a synchronous .then(attempt) recursion would starve macrotasks
+        // (timers/I/O) and prevent in-flight connects from releasing their
+        // slots.
+        if (this.getTotalConnectionCount() >= this.maxTotalConnections) {
+          this.evictOldestIdle(before).then((evicted) => {
+            setTimeout(attempt, evicted ? 0 : 250);
+          });
+          return;
+        }
+        setTimeout(attempt, 250);
+      };
+      attempt();
+    });
   }
 
   /**
@@ -178,9 +454,12 @@ export class McpServerPool {
 
     // Check if we already have an active session for this sessionId and server
     if (this.activeSessions[sessionId]?.[serverUuid]) {
-      // Touch timestamp on every access so SESSION_LIFETIME acts as idle timeout, not hard TTL
+      const cached = this.activeSessions[sessionId][serverUuid];
+      // Touch lastUsedAt on every access so SESSION_LIFETIME acts as idle
+      // timeout (not a hard TTL) and the LRU eviction sees recent activity.
+      cached.lastUsedAt = Date.now();
       this.sessionTimestamps[sessionId] = Date.now();
-      return this.activeSessions[sessionId][serverUuid];
+      return cached;
     }
 
     // Initialize session if it doesn't exist
@@ -200,21 +479,24 @@ export class McpServerPool {
         delete this.idleSessions[serverUuid];
         this.activeSessions[sessionId][serverUuid] = idleClient;
         this.sessionToServers[sessionId].add(serverUuid);
+        idleClient.lastUsedAt = Date.now();
 
         logger.info(
           `Converted idle session to active for server ${serverUuid}, session ${sessionId}`,
         );
 
-        // Create a new idle session to replace the one we just used (ASYNC - NON-BLOCKING)
-        this.createIdleSessionAsync(serverUuid, params, namespaceUuid);
+        // No replacement idle backfill — the next request recycles this
+        // session to idle via cleanupSession or spawns on demand.
 
         return idleClient;
       }
     }
 
-    // No idle session available — check per-server cap before spawning
+    // No idle session available — check per-server cap before spawning. If at
+    // the cap, try to reuse the oldest active connection for this server; if
+    // none is reusable, evict its LRU active slot to make room (a mid-flight
+    // server must always be able to obtain a slot rather than be refused).
     if (!this.canCreateConnectionForServer(serverUuid)) {
-      // At cap: reuse the oldest active connection instead of spawning
       const reusable = this.findOldestActiveConnectionForServer(serverUuid);
       if (reusable) {
         logger.info(
@@ -222,7 +504,19 @@ export class McpServerPool {
         );
         this.activeSessions[sessionId][serverUuid] = reusable;
         this.sessionToServers[sessionId].add(serverUuid);
+        reusable.lastUsedAt = Date.now();
         return reusable;
+      }
+      // Not reusable — free a slot by evicting this server's LRU active
+      // connection, then fall through to spawn a fresh one.
+      await this.evictOldestActiveConnectionForServer(serverUuid);
+      // Re-evaluate per-server count after eviction (it may have made room,
+      // and the count must be re-checked before we spawn).
+      if (!this.canCreateConnectionForServer(serverUuid)) {
+        logger.error(
+          `Per-server cap still exceeded for ${serverUuid} after LRU eviction; refusing to spawn`,
+        );
+        return undefined;
       }
     }
 
@@ -244,19 +538,25 @@ export class McpServerPool {
       return this.activeSessions[sessionId][serverUuid];
     }
 
+    // Guard a race with cleanupSession(): the session's map entry may have
+    // been deleted while we were awaiting the connect. Store into a fresh
+    // entry rather than a deleted object (which would throw and strand the
+    // new process).
+    if (!this.activeSessions[sessionId]) {
+      this.activeSessions[sessionId] = {};
+      this.sessionToServers[sessionId] = new Set();
+      this.sessionTimestamps[sessionId] = Date.now();
+    }
     this.activeSessions[sessionId][serverUuid] = newClient;
     this.sessionToServers[sessionId].add(serverUuid);
+    newClient.lastUsedAt = Date.now();
+    if (namespaceUuid) {
+      this.sessionNamespaces.set(sessionId, namespaceUuid);
+    }
 
     logger.info(
       `Created new active session for server ${serverUuid}, session ${sessionId}`,
     );
-
-    // Only pre-warm idle pool for servers that don't require forwarded headers.
-    // Idle sessions are created without per-client headers, so they can't be
-    // reused when per-client header forwarding is configured.
-    if (!serverRequiresForwardedHeaders(params)) {
-      this.createIdleSessionAsync(serverUuid, params, namespaceUuid);
-    }
 
     return newClient;
   }
@@ -276,56 +576,99 @@ export class McpServerPool {
       return undefined;
     }
 
-    logger.info(
-      `Creating new connection for server ${params.name} (${params.uuid}) with namespace: ${namespaceUuid || "none"}`,
-    );
-    metamcpLogStore.addLog(
-      params.name,
-      "info",
-      `Creating new connection for namespace ${namespaceUuid || "none"}`,
-    );
-
-    const connectedClient = await connectMetaMcpClient(
-      params,
-      (exitCode, signal) => {
-        logger.info(
-          `Crash handler callback called for server ${params.name} (${params.uuid}) with namespace: ${namespaceUuid || "none"}`,
+    // Per-namespace cap: prevent a busy namespace from starving others.
+    if (namespaceUuid && this.maxConnectionsPerNamespace > 0) {
+      const nsCount = this.namespaceConnections.get(namespaceUuid) || 0;
+      if (nsCount >= this.maxConnectionsPerNamespace) {
+        logger.warn(
+          `Skipping connection for server ${params.name} (${params.uuid}) - namespace ${namespaceUuid} at cap ${nsCount}/${this.maxConnectionsPerNamespace}`,
         );
-
-        // Handle process crash - always set up crash handler
-        if (namespaceUuid) {
-          // If we have a namespace context, use it
-          this.handleServerCrash(
-            params.uuid,
-            namespaceUuid,
-            exitCode,
-            signal,
-          ).catch((error) => {
-            logger.error(
-              `Error handling server crash for ${params.uuid} in ${namespaceUuid}:`,
-              error,
-            );
-          });
-        } else {
-          // If no namespace context, still track the crash globally
-          this.handleServerCrashWithoutNamespace(
-            params.uuid,
-            exitCode,
-            signal,
-          ).catch((error) => {
-            logger.error(
-              `Error handling server crash for ${params.uuid} (no namespace):`,
-              error,
-            );
-          });
-        }
-      },
-    );
-    if (!connectedClient) {
-      return undefined;
+        return undefined;
+      }
     }
 
-    return connectedClient;
+    // Bound spawn concurrency. A cold start can queue many servers behind
+    // this gate instead of firing ~22 simultaneous spawns that each blow
+    // past the SDK connect timeout.
+    const before = Date.now();
+    const release = await this.acquireSpawnSlot(before);
+
+    // Track the connection against its namespace (for the per-namespace cap).
+    // We increment AFTER acquiring a spawn slot but BEFORE the connect, and
+    // decrement on cleanup/failure.
+    if (namespaceUuid) {
+      this.namespaceConnections.set(
+        namespaceUuid,
+        (this.namespaceConnections.get(namespaceUuid) || 0) + 1,
+      );
+    }
+
+    try {
+      logger.info(
+        `Creating new connection for server ${params.name} (${params.uuid}) with namespace: ${namespaceUuid || "none"}`,
+      );
+      metamcpLogStore.addLog(
+        params.name,
+        "info",
+        `Creating new connection for namespace ${namespaceUuid || "none"}`,
+      );
+
+      const connectedClient = await connectMetaMcpClient(
+        params,
+        (exitCode, signal) => {
+          logger.info(
+            `Crash handler callback called for server ${params.name} (${params.uuid}) with namespace: ${namespaceUuid || "none"}`,
+          );
+
+          // Handle process crash - always set up crash handler
+          if (namespaceUuid) {
+            // If we have a namespace context, use it
+            this.handleServerCrash(
+              params.uuid,
+              namespaceUuid,
+              exitCode,
+              signal,
+            ).catch((error) => {
+              logger.error(
+                `Error handling server crash for ${params.uuid} in ${namespaceUuid}:`,
+                error,
+              );
+            });
+          } else {
+            // If no namespace context, still track the crash globally
+            this.handleServerCrashWithoutNamespace(
+              params.uuid,
+              exitCode,
+              signal,
+            ).catch((error) => {
+              logger.error(
+                `Error handling server crash for ${params.uuid} (no namespace):`,
+                error,
+              );
+            });
+          }
+        },
+      );
+      if (!connectedClient) {
+        // Connect failed — roll back the namespace counter.
+        if (namespaceUuid) {
+          const nsCount = this.namespaceConnections.get(namespaceUuid) || 0;
+          this.namespaceConnections.set(
+            namespaceUuid,
+            Math.max(0, nsCount - 1),
+          );
+        }
+        return undefined;
+      }
+
+      // Initialize the LRU touch used by idle/LRU eviction and the per-server
+      // idle timeout. Created connections count as freshly-used.
+      connectedClient.lastUsedAt = Date.now();
+
+      return connectedClient;
+    } finally {
+      release();
+    }
   }
 
   /**
@@ -470,21 +813,33 @@ export class McpServerPool {
   }
 
   /**
-   * Ensure idle sessions exist for all servers
+   * Ensure idle sessions exist for all servers.
+   *
+   * Prewarms sequentially (each spawn still passes through the bounded
+   * spawn-concurrency gate in createNewConnection). The old implementation
+   * fired Promise.allSettled over every server at once, so a cold start
+   * spawned ~22 simultaneous processes and blew past the SDK connect
+   * timeout (-32001 / -32000). Sequential prewarm trades wall time for
+   * connect success; the lazy on-first-use path in getSession covers the
+   * gap until warm.
    */
   async ensureIdleSessions(
     serverParams: Record<string, ServerParameters>,
     namespaceUuid?: string,
   ): Promise<void> {
-    const promises = Object.entries(serverParams).map(
-      async ([uuid, params]) => {
-        if (!this.idleSessions[uuid]) {
+    for (const [uuid, params] of Object.entries(serverParams)) {
+      if (!this.idleSessions[uuid]) {
+        try {
           await this.createIdleSession(uuid, params, namespaceUuid);
+        } catch (error) {
+          // One bad server must not stall the rest of the prewarm.
+          logger.error(
+            `Error prewarming idle session for server ${uuid}:`,
+            error,
+          );
         }
-      },
-    );
-
-    await Promise.allSettled(promises);
+      }
+    }
   }
 
   /**
@@ -500,17 +855,25 @@ export class McpServerPool {
     let recycled = 0;
     let destroyed = 0;
 
-    // Try to recycle each connection back to idle pool
+    // Try to recycle each connection back to idle pool. The idle pool is
+    // capped at ONE healthy session per server UUID, so a second connection
+    // for the same server is destroyed rather than stacked (the old behavior
+    // let recycling + backfill grow the active map unboundedly — the leak).
     for (const [serverUuid, client] of Object.entries(activeSession)) {
       if (!this.idleSessions[serverUuid]) {
         // No idle session for this server — recycle the connection
         this.idleSessions[serverUuid] = client;
+        // Touch so the LRU idle eviction sees it as freshly-used, and the
+        // per-server idle timeout starts counting from the recycle moment.
+        client.lastUsedAt = Date.now();
         recycled++;
         logger.info(
           `Recycled active connection for server ${serverUuid} to idle pool (session ${sessionId})`,
         );
       } else {
-        // Already have an idle session — destroy the extra
+        // Already have an idle session — destroy the extra. No replacement
+        // backfill: an extra active connection for a server we already hold
+        // idle is not a reason to spawn another process.
         try {
           await client.cleanup();
         } catch (error) {
@@ -520,6 +883,8 @@ export class McpServerPool {
           );
         }
         destroyed++;
+        // Decrement the namespace count for the destroyed connection.
+        this.decrementNamespaceConnection(sessionId);
       }
     }
 
@@ -532,9 +897,23 @@ export class McpServerPool {
     // Clean up session to servers mapping
     delete this.sessionToServers[sessionId];
 
+    // Clean up session namespace tracking
+    this.sessionNamespaces.delete(sessionId);
+
     logger.info(
       `Cleaned up session ${sessionId} (recycled: ${recycled}, destroyed: ${destroyed})`,
     );
+  }
+
+  /**
+   * Decrement the live connection count for a session's namespace (called when a
+   * connection is destroyed, not recycled).
+   */
+  private decrementNamespaceConnection(sessionId: string): void {
+    const ns = this.sessionNamespaces.get(sessionId);
+    if (!ns) return;
+    const count = this.namespaceConnections.get(ns) || 0;
+    this.namespaceConnections.set(ns, Math.max(0, count - 1));
   }
 
   /**
@@ -560,6 +939,8 @@ export class McpServerPool {
     this.sessionToServers = {};
     this.sessionTimestamps = {};
     this.serverParamsCache = {};
+    this.namespaceConnections.clear();
+    this.sessionNamespaces.clear();
 
     // Bump all known generations (never reset to {}) so any in-flight idle
     // creation that started before cleanupAll() resolves with a stale value
@@ -613,6 +994,8 @@ export class McpServerPool {
       idleServerUuids: Object.keys(this.idleSessions),
       perServerCounts,
       maxConnectionsPerServer: this.maxConnectionsPerServer,
+      lastEvictedAt: this.lastEvictedAt,
+      evictionCount: this.evictionCount,
     };
   }
 
@@ -642,6 +1025,49 @@ export class McpServerPool {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Structured diagnostics for the pool (health endpoints / debug UI).
+   * Exposes the idle/active/pending/evicted accounting the health loop logs.
+   */
+  async getDebugInfo(): Promise<McpServerPoolDebugInfo> {
+    const idle = Object.keys(this.idleSessions).length;
+    const active = Object.keys(this.activeSessions).reduce(
+      (total, sessionId) =>
+        total + Object.keys(this.activeSessions[sessionId]).length,
+      0,
+    );
+    const pending = this.creatingIdleSessions.size;
+
+    let sessionLifetimeMs: number | null;
+    try {
+      sessionLifetimeMs = await configService.getSessionLifetime();
+    } catch {
+      sessionLifetimeMs = null;
+    }
+
+    const perServerCounts: Record<string, number> = {};
+    for (const serverUuid of Object.keys(this.serverParamsCache)) {
+      perServerCounts[serverUuid] = this.countConnectionsForServer(serverUuid);
+    }
+
+    return {
+      idle,
+      active,
+      pending,
+      evicted: this.evictionCount,
+      lastEvictedAt: this.lastEvictedAt,
+      total: idle + active + pending,
+      maxTotalConnections: this.maxTotalConnections,
+      maxConnectionsPerServer: this.maxConnectionsPerServer,
+      spawnConcurrency: this.maxSpawnConcurrency,
+      idleTimeoutMs: this.idleTimeoutMs,
+      sessionLifetimeMs,
+      activeSessionIds: Object.keys(this.activeSessions),
+      idleServerUuids: Object.keys(this.idleSessions),
+      perServerCounts,
+    };
   }
 
   /**
@@ -1046,27 +1472,73 @@ export class McpServerPool {
   }
 
   /**
-   * Check health of idle sessions by pinging them.
-   * Dead sessions are cleaned up and recreated.
-   * Servers in ERROR state whose crash counters have been reset are retried.
+   * Check health of idle sessions.
+   *
+   * With lazy spawn-on-demand the health loop's job is NO LONGER to keep the
+   * pool warm — a dead session is caught by the recovery retry on the next
+   * real call, not by a 60s timer. So by default this loop only:
+   *   1. recycles idle sessions that have been untouched past idleTimeoutMs
+   *      (a parked process must not be held forever), and
+   *   2. runs the diagnostics accounting.
+   *
+   * The eager ping + recreate-on-false-negative that used to respawn a
+   * healthy-but-idle server every 60s is opt-in via MCP_IDLE_HEALTH_PING=1,
+   * and even then a session is only recreated if it hasn't served a request
+   * within the recreate cooldown AND has failed the ping the configured
+   * number of consecutive times — so a healthy session is never spawned
+   * "because a timer fired".
    */
   private async checkIdleSessionHealth(): Promise<void> {
     const serverUuids = Object.keys(this.idleSessions);
-    if (serverUuids.length === 0) {
-      return;
-    }
 
     for (const serverUuid of serverUuids) {
       const client = this.idleSessions[serverUuid];
       if (!client) continue;
 
-      try {
-        // Ping with a 5-second timeout
-        await client.client.ping({ timeout: 5000 });
-      } catch {
-        logger.warn(
-          `Idle session health check failed for server ${serverUuid}, recreating...`,
+      // Per-server idle timeout: a parked idle session must not hold a
+      // process forever. Recycle if untouched past idleTimeoutMs.
+      if (
+        client.lastUsedAt &&
+        Date.now() - client.lastUsedAt > this.idleTimeoutMs
+      ) {
+        logger.info(
+          `Idle session for server ${serverUuid} idle past ${this.idleTimeoutMs}ms, closing...`,
         );
+        await client.cleanup();
+        delete this.idleSessions[serverUuid];
+        // No recreate — the next real call spawns on demand.
+        this.healthCheckFailures.delete(serverUuid);
+        continue;
+      }
+
+      // Eager ping is opt-in and guarded: skip sessions that recently served
+      // a request (the caller just used it — it's alive), and only recreate
+      // after the cooldown + consecutive-failure threshold.
+      if (!this.idleHealthPingEnabled) continue;
+
+      if (
+        client.lastUsedAt &&
+        Date.now() - client.lastUsedAt < this.healthCheckRecreateCooldownMs
+      ) {
+        // Recently used — leave it alone.
+        continue;
+      }
+
+      try {
+        await client.client.ping({ timeout: this.healthCheckTimeoutMs });
+        this.healthCheckFailures.delete(serverUuid);
+      } catch {
+        const failures = (this.healthCheckFailures.get(serverUuid) || 0) + 1;
+        this.healthCheckFailures.set(serverUuid, failures);
+        logger.warn(
+          `Idle session health check failed for server ${serverUuid} (failure ${failures}/${this.healthCheckRecreateThreshold}); ` +
+            (failures >= this.healthCheckRecreateThreshold
+              ? `recreating after ${failures} consecutive failures`
+              : `not recreating yet — threshold not reached`),
+        );
+        if (failures < this.healthCheckRecreateThreshold) {
+          continue;
+        }
 
         // Clean up the dead session
         try {
@@ -1075,33 +1547,30 @@ export class McpServerPool {
           // Already dead, ignore cleanup errors
         }
         delete this.idleSessions[serverUuid];
+        this.healthCheckFailures.delete(serverUuid);
 
-        // Reset error state so we can retry
+        // Reset error state so a real request can retry. No background
+        // recreate here — the next real call spawns on demand.
         await serverErrorTracker.resetServerErrorState(serverUuid);
-
-        // Recreate if we have cached params
-        const params = this.serverParamsCache[serverUuid];
-        if (params) {
-          this.createIdleSessionAsync(serverUuid, params);
-        }
       }
     }
 
-    // Also check for servers in ERROR state that have cached params but no idle session.
-    // If they were reset (e.g., on startup), we should try to recreate them.
-    for (const [serverUuid, params] of Object.entries(this.serverParamsCache)) {
-      if (
-        !this.idleSessions[serverUuid] &&
-        !this.creatingIdleSessions.has(serverUuid)
-      ) {
-        const isError =
-          await serverErrorTracker.isServerInErrorState(serverUuid);
-        if (!isError) {
-          // Not in error and no idle session - try to create one
-          this.createIdleSessionAsync(serverUuid, params);
-        }
-      }
-    }
+    // No background backfill. A server with cached params but no idle slot is
+    // not spawned here — a session is created only when a real request needs
+    // it (lazy spawn-on-demand).
+
+    // Diagnostics: periodic pool accounting so the leak/storm footprint is
+    // visible in the logs without needing a health probe.
+    const active = Object.keys(this.activeSessions).reduce(
+      (total, sessionId) =>
+        total + Object.keys(this.activeSessions[sessionId]).length,
+      0,
+    );
+    const idle = Object.keys(this.idleSessions).length;
+    const pending = this.creatingIdleSessions.size;
+    logger.info(
+      `MCP pool diagnostics: idle=${idle} active(${Object.keys(this.activeSessions).length})=${active} pending=${pending} evicted=${this.evictionCount} lastEvictedAt=${this.lastEvictedAt ?? "never"} total=${idle + active + pending}/${this.maxTotalConnections}`,
+    );
   }
 
   /**

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -3,6 +3,7 @@ import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import {
   CallToolRequestSchema,
   CallToolResult,
+  CallToolResultSchema,
   CompatibilityCallToolResultSchema,
   GetPromptRequestSchema,
   GetPromptResultSchema,
@@ -22,10 +23,12 @@ import {
   ResourceTemplate,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 
 import logger from "@/utils/logger";
 
 import { namespacesRepository } from "../../db/repositories/namespaces.repo";
+import { toolsRepository } from "../../db/repositories/tools.repo";
 import { toolsImplementations } from "../../trpc/tools.impl";
 import { getAdminToolsContext } from "../admin-mcp/admin-session-context";
 import {
@@ -57,58 +60,74 @@ import {
   mapOverrideNameToOriginal,
 } from "./metamcp-middleware/tool-overrides.functional";
 import { isBackendSessionLostError } from "./session-error";
+import { normalizeCallToolResult } from "./call-tool-result";
 import { parseToolName } from "./tool-name-parser";
+import { backgroundToolsSync } from "./background-tools-sync";
+import { circuitBreaker } from "./circuit-breaker";
+import { filterOutOverrideTools } from "./override-filter";
 import { toolsSyncCache } from "./tools-sync-cache";
 import { sanitizeName } from "./utils";
 
 /**
- * Filter out tools that are overrides of existing tools to prevent duplicates in database
- * Uses the existing tool overrides cache for optimal performance
+ * Rate-limited DEGRADED logger: aggregates per-namespace degradation and emits
+ * at most one log line per window (default 60s) instead of spamming per request.
  */
-async function filterOutOverrideTools(
-  tools: Tool[],
-  namespaceUuid: string,
-  serverName: string,
-): Promise<Tool[]> {
-  if (!tools || tools.length === 0) {
-    return tools;
+const degradedLogTimestamps: Map<string, number> = new Map();
+const DEGRADED_LOG_WINDOW_MS = 60_000;
+
+function shouldLogDegraded(namespaceUuid: string): boolean {
+  const now = Date.now();
+  const last = degradedLogTimestamps.get(namespaceUuid) || 0;
+  if (now - last >= DEGRADED_LOG_WINDOW_MS) {
+    degradedLogTimestamps.set(namespaceUuid, now);
+    return true;
   }
+  return false;
+}
 
-  const filteredTools: Tool[] = [];
-
-  await Promise.allSettled(
-    tools.map(async (tool) => {
-      try {
-        // Check if this tool name is actually an override name for an existing tool
-        // by using the existing mapOverrideNameToOriginal function
-        const fullToolName = `${sanitizeName(serverName)}__${tool.name}`;
-        const originalName = await mapOverrideNameToOriginal(
-          fullToolName,
-          namespaceUuid,
-          true, // use cache
-        );
-
-        // If the original name is different from the current name,
-        // this tool is an override and should be filtered out
-        if (originalName !== fullToolName) {
-          // This is an override, skip it (don't save to database)
-          return;
-        }
-
-        // This is not an override, include it
-        filteredTools.push(tool);
-      } catch (error) {
-        logger.error(
-          `Error checking if tool ${tool.name} is an override:`,
-          error,
-        );
-        // On error, include the tool (fail-safe behavior)
-        filteredTools.push(tool);
-      }
-    }),
+/**
+ * Bound a getSession() call with a deadline. The pool's getSession can block
+ * for a cold spawn (createNewConnection up to MCP_STDIO_CONNECT_TIMEOUT_MS),
+ * and when that happens inside a fan-out (tools/list, prompts/list, ...) it
+ * stalls the WHOLE aggregate HTTP response past the client's deadline — the
+ * "tools/list never returns" symptom. On timeout we return undefined; the
+ * caller surfaces the server via _meta.pending / failedServers instead of
+ * stalling. Default 10s; override MCP_TOOLS_LIST_TIMEOUT_MS. The pool still
+ * spawns the server in the background (the deadline only abandons THIS
+ * request's wait, not the connection).
+ */
+async function getSessionWithDeadline(
+  sessionId: string,
+  serverUuid: string,
+  params: Parameters<typeof mcpServerPool.getSession>[2],
+  namespaceUuid?: string,
+): Promise<ConnectedClient | undefined> {
+  const timeoutMs = parseInt(
+    process.env.MCP_TOOLS_LIST_TIMEOUT_MS || "10000",
+    10,
   );
-
-  return filteredTools;
+  const sessionPromise = mcpServerPool.getSession(
+    sessionId,
+    serverUuid,
+    params,
+    namespaceUuid,
+  );
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<ConnectedClient | undefined>((resolve) => {
+    timer = setTimeout(() => {
+      logger.warn(
+        `[fan-out] getSession deadline exceeded for server ${serverUuid} after ${timeoutMs}ms — returning as pending; spawn continues in background`,
+      );
+      resolve(undefined);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([sessionPromise, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export const createServer = async (
@@ -174,7 +193,7 @@ export const createServer = async (
     request,
     context,
   ) => {
-    console.log(
+    logger.debug(
       "[DEBUG-TOOLS] 🔍 tools/list called for namespace:",
       namespaceUuid,
     );
@@ -183,6 +202,90 @@ export const createServer = async (
       context.namespaceUuid,
       includeInactiveServers,
     );
+
+    // ---- Serve-from-DB fast path ----
+    // Read the fully-scoped tool list for the namespace from the `tools` table
+    // (one indexed query, no backend I/O). This is the hot path that keeps
+    // tools/list fast under many backends. Stale/absent servers are flagged
+    // PENDING and refreshed in the background (or fetched one-off below).
+    try {
+      const dbTools = await toolsRepository.readToolsForNamespace(
+        context.namespaceUuid,
+      );
+
+      // If we have cached tools for this namespace, prefer them. Servers with
+      // fresh DB rows are served from the DB; servers that are stale or absent
+      // are marked PENDING and a background refresh is kicked.
+      const serverUuids = Object.keys(serverParams);
+      const freshUuids = new Set<string>();
+      const pendingServers: string[] = [];
+
+      for (const serverUuid of serverUuids) {
+        if (backgroundToolsSync.isFresh(serverUuid)) {
+          freshUuids.add(serverUuid);
+        } else {
+          pendingServers.push(serverUuid);
+        }
+      }
+
+      if (dbTools.length > 0) {
+        // Trigger background refresh for stale/absent servers (debounced,
+        // non-blocking). The request returns immediately from the DB.
+        for (const [serverUuid, params] of Object.entries(serverParams)) {
+          if (!freshUuids.has(serverUuid)) {
+            backgroundToolsSync.ensureFresh(
+              serverUuid,
+              params,
+              context.namespaceUuid,
+            );
+          }
+        }
+
+        // Surface circuit-open servers as pending (DEGRADED surfacing): a
+        // tripped backend's tools are still served from DB (last-known) but
+        // the client sees the server needs a retry, not a hang.
+        for (const serverUuid of Object.keys(serverParams)) {
+          if (circuitBreaker.isOpen(serverUuid)) {
+            if (!pendingServers.includes(serverUuid)) {
+              pendingServers.push(serverUuid);
+            }
+          }
+        }
+
+        const dbToolsWithName = dbTools.map((tool) => {
+          const serverName = serverParams[tool.mcp_server_uuid]?.name || "";
+          const toolName = `${sanitizeName(serverName)}__${tool.name}`;
+          // Map the DB row (DatabaseTool: toolSchema) to the SDK Tool shape
+          // (inputSchema) and drop DB-only fields so the MCP client sees the
+          // standard { name, description, inputSchema } tool.
+          return {
+            name: toolName,
+            description: tool.description ?? undefined,
+            inputSchema: tool.toolSchema,
+          };
+        });
+
+        logger.debug(
+          `[DEBUG-TOOLS] ✅ tools/list served from DB in ${(performance.now() - startTime).toFixed(2)}ms (${dbToolsWithName.length} tools, ${pendingServers.length} pending)`,
+        );
+
+        return {
+          tools: dbToolsWithName,
+          ...(pendingServers.length > 0
+            ? { _meta: { pending: pendingServers } }
+            : {}),
+        };
+      }
+      // No cached tools for this namespace — fall through to the backend
+      // fan-out (bounded) below.
+    } catch (dbError) {
+      // DB read failed — fall through to the backend fan-out rather than
+      // returning an error.
+      logger.error(
+        `tools/list: DB read failed for namespace ${context.namespaceUuid}, falling back to backend fan-out:`,
+        dbError,
+      );
+    }
 
     // Extract forwarded headers from client request for servers that need them
     const forwardedHeadersByServer = context.clientRequestHeaders
@@ -203,39 +306,51 @@ export const createServer = async (
     // We'll filter servers during processing after getting sessions to check actual MCP server names
     const allServerEntries = Object.entries(serverParams);
 
-    console.log(
+    logger.debug(
       `[DEBUG-TOOLS] 📋 Processing ${allServerEntries.length} servers`,
     );
 
     // Cold-start warmup: if pool has 0 idle + 0 active sessions but servers
-    // exist in DB, trigger a blocking warmup before tools/list responds.
-    // This prevents 0-tool responses after idle timeout expires all connections.
+    // exist in DB, trigger a LAZY warmup. This used to block on
+    // ensureIdleSessions() — a synchronous fan-out that spawned every server
+    // at once and blew past the connect timeout (the -32001/-32000 storm).
+    // Instead, clear error states and kick off the bounded, sequential
+    // prewarm in the background; the per-server getSession() calls below
+    // connect on demand and are covered by the extended connect timeout.
     const poolStatus = mcpServerPool.getPoolStatus();
     if (
       poolStatus.idle === 0 &&
       poolStatus.active === 0 &&
       allServerEntries.length > 0
     ) {
-      console.log(
-        `[DEBUG-TOOLS] ⚠️ Cold start: 0 idle, 0 active sessions but ${allServerEntries.length} servers registered. Warming up...`,
+      logger.debug(
+        `[DEBUG-TOOLS] ⚠️ Cold start: 0 idle, 0 active sessions but ${allServerEntries.length} servers registered. Background prewarm started.`,
       );
       for (const [uuid] of allServerEntries) {
         await mcpServerPool.resetServerErrorState(uuid);
       }
-      await mcpServerPool.ensureIdleSessions(serverParams, namespaceUuid);
-      const afterStatus = mcpServerPool.getPoolStatus();
-      console.log(
-        `[DEBUG-TOOLS] ✅ Pool warmup complete: ${afterStatus.idle} idle, ${afterStatus.active} active`,
-      );
+      // Fire-and-forget: the prewarm is bounded (sequential, gated) and the
+      // fan-out below will lazy-connect servers that are still cold.
+      void mcpServerPool
+        .ensureIdleSessions(serverParams, namespaceUuid)
+        .then(() => {
+          const afterStatus = mcpServerPool.getPoolStatus();
+          logger.debug(
+            `[DEBUG-TOOLS] ✅ Pool warmup complete: ${afterStatus.idle} idle, ${afterStatus.active} active`,
+          );
+        })
+        .catch((error) => {
+          logger.error("[DEBUG-TOOLS] ❌ Pool warmup failed:", error);
+        });
     }
 
     await Promise.allSettled(
       allServerEntries.map(async ([mcpServerUuid, params]) => {
-        console.log(`[DEBUG-TOOLS] 🔧 Server: ${params.name || mcpServerUuid}`);
+        logger.debug(`[DEBUG-TOOLS] 🔧 Server: ${params.name || mcpServerUuid}`);
 
         // Skip if we've already visited this server to prevent circular references
         if (visitedServers.has(mcpServerUuid)) {
-          console.log(
+          logger.debug(
             `[DEBUG-TOOLS] ⏭️  Skipping already visited: ${params.name}`,
           );
           return;
@@ -252,20 +367,20 @@ export const createServer = async (
             }
           : params;
 
-        const session = await mcpServerPool.getSession(
+        const session = await getSessionWithDeadline(
           context.sessionId,
           mcpServerUuid,
           effectiveParams,
           namespaceUuid,
         );
         if (!session) {
-          console.log(`[DEBUG-TOOLS] ❌ No session for: ${params.name}`);
+          logger.debug(`[DEBUG-TOOLS] ❌ No session for: ${params.name}`);
           // No pooled session and the pool couldn't create one — server is
-          // ERROR-gated, connection-capped, or unreachable. Error level: this
-          // server is silently missing from the namespace's tool surface
-          // until the pool recovers.
+          // ERROR-gated, connection-capped, deadline-exceeded, or unreachable.
+          // Error level: this server is silently missing from the namespace's
+          // tool surface until the pool recovers.
           logger.error(
-            `tools/list: no session available for server ${params.name || mcpServerUuid} — excluded from namespace response (error state, connection cap, or backend unreachable)`,
+            `tools/list: no session available for server ${params.name || mcpServerUuid} — excluded from namespace response (error state, connection cap, deadline, or backend unreachable)`,
           );
           failedServers.push(params.name || mcpServerUuid);
           return;
@@ -301,6 +416,13 @@ export const createServer = async (
         try {
           const toolFetchStart = performance.now();
 
+          // Bound each backend's tools/list with the namespace-aware MCP timeout
+          // so a single hung backend (OAuth re-auth, cold package install)
+          // can't stall the whole namespace aggregation.
+          const listTimeout = await configService.getMcpTimeoutForNamespace(
+            namespace?.name || "",
+          );
+
           // Paginated tool discovery - load all pages automatically
           const fetchAllToolPages = async (
             active: ConnectedClient,
@@ -319,6 +441,10 @@ export const createServer = async (
                   },
                 },
                 ListToolsResultSchema,
+                {
+                  timeout: listTimeout,
+                  resetTimeoutOnProgress: true,
+                },
               );
 
               if (result.tools && result.tools.length > 0) {
@@ -351,7 +477,7 @@ export const createServer = async (
             },
           });
 
-          console.log(
+          logger.debug(
             `[DEBUG-TOOLS] ⏱️  Fetched ${allServerTools.length} tools from ${serverName} in ${(performance.now() - toolFetchStart).toFixed(2)}ms`,
           );
 
@@ -366,7 +492,7 @@ export const createServer = async (
               toolNames,
             );
 
-            console.log(
+            logger.debug(
               `[DEBUG-TOOLS] 🔍 Hash check for ${serverName}: ${hasChanged ? "CHANGED" : "UNCHANGED"}`,
             );
 
@@ -417,7 +543,7 @@ export const createServer = async (
     );
 
     const totalTime = performance.now() - startTime;
-    console.log(
+    logger.debug(
       `[DEBUG-TOOLS] ✅ tools/list completed in ${totalTime.toFixed(2)}ms, returning ${allTools.length} tools`,
     );
 
@@ -425,13 +551,26 @@ export const createServer = async (
     // failed even after the recovery retry (or had no session). The response
     // is still returned (partial truth beats a hard error for the surviving
     // servers) but the failure must be loud enough for log-based monitoring.
+    //
+    // A warming/failed server is surfaced to the client as a `_meta`-style
+    // `pending` marker (not a hard failure): a client that checks it can
+    // retry, and a client that ignores it still gets the healthy tools.
     if (failedServers.length > 0) {
-      logger.error(
-        `tools/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length}/${allServerEntries.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allTools.length} tools`,
-      );
+      // Quiet DEGRADED: emit at most once per 60s per namespace so a steady
+      // degradation doesn't flood the log; the client still gets _meta.pending.
+      if (shouldLogDegraded(namespaceUuid)) {
+        logger.error(
+          `tools/list DEGRADED for namespace ${namespaceUuid}: ${failedServers.length}/${allServerEntries.length} backend server(s) failed (${failedServers.join(", ")}); returning ${allTools.length} tools`,
+        );
+      }
     }
 
-    return { tools: allTools };
+    return {
+      tools: allTools,
+      ...(failedServers.length > 0
+        ? { _meta: { pending: failedServers } }
+        : {}),
+    };
   };
 
   // Original Call Tool Handler
@@ -557,7 +696,10 @@ export const createServer = async (
     // Get configurable timeout values
     const resetTimeoutOnProgress =
       await configService.getMcpResetTimeoutOnProgress();
-    const timeout = await configService.getMcpTimeout();
+    // Per-namespace timeout: honor MCP_TIMEOUT_<NS>_MS override, else global.
+    const timeout = await configService.getMcpTimeoutForNamespace(
+      namespace?.name || "",
+    );
     const maxTotalTimeout = await configService.getMcpMaxTotalTimeout();
 
     const mcpRequestOptions: RequestOptions = {
@@ -567,8 +709,15 @@ export const createServer = async (
       maxTotalTimeout,
     };
 
-    const callOnce = (session: ConnectedClient) =>
-      session.client.request(
+    // Fetch the backend result with a PERMISSIVE schema (z.unknown) so the SDK
+    // returns the raw payload instead of hard-failing -32602 on a malformed
+    // `content` shape during validation. We normalize to the SDK shape after,
+    // and only then validate — so a backend's malformed output never becomes a
+    // client-facing error.
+    const callOnce = async (
+      session: ConnectedClient,
+    ): Promise<CallToolResult> => {
+      const raw = await session.client.request(
         {
           method: "tools/call",
           params: {
@@ -577,13 +726,37 @@ export const createServer = async (
             _meta: request.params._meta,
           },
         },
-        CompatibilityCallToolResultSchema,
+        z.unknown(),
         mcpRequestOptions,
       );
+      // Normalize the backend's CallToolResult so a non-conforming shape never
+      // becomes a client-facing -32602 (zod hard-fail on the SDK shape). A
+      // backend's malformed output is a reason to degrade, not to break the
+      // call for the client.
+      const result = normalizeCallToolResult(raw as CallToolResult, serverUuid);
+      // Validate the normalized result: if it STILL doesn't conform (e.g. the
+      // backend returned a fundamentally non-result object), surface a clean
+      // retryable error rather than a raw zod dump.
+      const parsed = CallToolResultSchema.safeParse(result);
+      if (!parsed.success) {
+        logger.error(
+          `[call-tool] backend ${serverUuid} returned an unshapable CallToolResult for tool "${name}"; returning clean error`,
+        );
+        throw new Error(
+          `Backend ${serverUuid} returned an invalid tools/call result for "${name}"`,
+        );
+      }
+      return parsed.data;
+    };
 
     try {
-      return (await callOnce(clientForTool)) as CallToolResult;
+      // Circuit breaker: a successful call resets the backend's failure count.
+      circuitBreaker.onSuccess(serverUuid);
+      return await callOnce(clientForTool);
     } catch (error) {
+      // Circuit breaker: a failed/timed-out call counts toward tripping.
+      circuitBreaker.onFailure(serverUuid);
+
       if (!isBackendSessionLostError(error)) {
         logger.error(
           `Error calling tool "${name}" through ${
@@ -592,6 +765,15 @@ export const createServer = async (
           error,
         );
         throw error;
+      }
+
+      // Circuit breaker: a tripped backend must not be spawned into on every
+      // call. Surface a clean retryable error; the breaker's half-open probe
+      // lets a real request through once the cooldown elapses.
+      if (circuitBreaker.isOpen(serverUuid)) {
+        throw new Error(
+          `Backend server ${serverUuid} is circuit-open; skipping re-initialize for tool "${name}"`,
+        );
       }
 
       logger.warn(
@@ -635,6 +817,21 @@ export const createServer = async (
           } after session re-initialize:`,
           retryError,
         );
+        // The retry's fresh spawn is registered in the pool but will never be
+        // recycled or evicted if the caller already gave up (its request timed
+        // out while we awaited the fresh connect). Invalidate + kill it so a
+        // failed recovery does not leak a spawned backend process forever
+        // (the pid-47 orphan pileup that pushed the container to 8.45GB/8GB).
+        // The invalidation cascades across every slot for this serverUuid and
+        // is idempotent — safe if another request already adopted this session.
+        await mcpServerPool
+          .invalidateServerConnection(sessionId, serverUuid)
+          .catch((invalidateError) => {
+            logger.error(
+              `Error cleaning up leaked fresh session for server ${serverUuid} after failed re-initialize:`,
+              invalidateError,
+            );
+          });
         throw retryError;
       }
     }

--- a/apps/backend/src/lib/metamcp/override-filter.ts
+++ b/apps/backend/src/lib/metamcp/override-filter.ts
@@ -1,0 +1,58 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+import logger from "@/utils/logger";
+
+import { mapOverrideNameToOriginal } from "./metamcp-middleware/tool-overrides.functional";
+import { sanitizeName } from "./utils";
+
+/**
+ * Filter out tools that are overrides of existing tools to prevent duplicates in the
+ * database. Shared by the proxy's tools/list sync path and the background tools-sync
+ * loop (extracted here to avoid a circular import between metamcp-proxy and
+ * background-tools-sync).
+ */
+export async function filterOutOverrideTools(
+  tools: Tool[],
+  namespaceUuid: string,
+  serverName: string,
+): Promise<Tool[]> {
+  if (!tools || tools.length === 0) {
+    return tools;
+  }
+
+  const filteredTools: Tool[] = [];
+
+  await Promise.allSettled(
+    tools.map(async (tool) => {
+      try {
+        // Check if this tool name is actually an override name for an existing tool
+        // by using the existing mapOverrideNameToOriginal function
+        const fullToolName = `${sanitizeName(serverName)}__${tool.name}`;
+        const originalName = await mapOverrideNameToOriginal(
+          fullToolName,
+          namespaceUuid,
+          true, // use cache
+        );
+
+        // If the original name is different from the current name,
+        // this tool is an override and should be filtered out
+        if (originalName !== fullToolName) {
+          // This is an override, skip it (don't save to database)
+          return;
+        }
+
+        // This is not an override, include it
+        filteredTools.push(tool);
+      } catch (error) {
+        logger.error(
+          `Error checking if tool ${tool.name} is an override:`,
+          error,
+        );
+        // On error, include the tool (fail-safe behavior)
+        filteredTools.push(tool);
+      }
+    }),
+  );
+
+  return filteredTools;
+}

--- a/apps/backend/src/lib/startup.ts
+++ b/apps/backend/src/lib/startup.ts
@@ -3,8 +3,10 @@ import { ServerParameters } from "@repo/zod-types";
 import { mcpServersRepository, namespacesRepository } from "../db/repositories";
 import { initializeEnvironmentConfiguration } from "./bootstrap.service";
 import { metaMcpServerPool } from "./metamcp";
+import { backgroundToolsSync } from "./metamcp/background-tools-sync";
 import { serverErrorTracker } from "./metamcp/server-error-tracker";
 import { convertDbServerToParams } from "./metamcp/utils";
+import { startRuntimePrewarm } from "./stdio-transport/prewarm";
 
 /**
  * Startup initialization that must happen before the HTTP server begins listening.
@@ -38,6 +40,11 @@ export async function initializeOnStartup(): Promise<void> {
   } else {
     console.log("Environment bootstrap disabled via BOOTSTRAP_ENABLE=false");
   }
+
+  // Runtime package prewarm (fire-and-forget): MCP_PREWARM_NPM / _UVX / _BUN
+  // pre-install stdio MCP packages into the user-level caches so cold spawns
+  // hit warm caches instead of downloading on first connect. Non-blocking.
+  startRuntimePrewarm();
 }
 
 /**
@@ -71,10 +78,16 @@ export async function initializeIdleServers() {
       );
     }
 
-    // Fetch ALL MCP servers from the database (not just namespace-associated ones)
-    console.log("Fetching all MCP servers from database...");
-    const allDbServers = await mcpServersRepository.findAll();
-    console.log(`Found ${allDbServers.length} total MCP servers in database`);
+    // Fetch MCP servers that have at least one ACTIVE namespace mapping. A
+    // server the operator turned off (status INACTIVE in namespace_server_mappings)
+    // must NOT be prewarmed at startup — otherwise the startup idle-prewarm
+    // keeps booting servers the UI says are off (and the tools/list path
+    // correctly filters them out via includeInactiveServers=false).
+    console.log("Fetching ACTIVE MCP servers from database...");
+    const allDbServers = await mcpServersRepository.findActiveByMappings();
+    console.log(
+      `Found ${allDbServers.length} active MCP servers in database (${allDbServers.length} with an ACTIVE namespace mapping)`,
+    );
 
     // Convert all database servers to ServerParameters format
     const allServerParams: Record<string, ServerParameters> = {};
@@ -89,12 +102,15 @@ export async function initializeIdleServers() {
       `Successfully converted ${Object.keys(allServerParams).length} MCP servers to ServerParameters format`,
     );
 
-    // Initialize idle sessions for the underlying MCP server pool with ALL servers
-    if (Object.keys(allServerParams).length > 0) {
+    // No boot prewarm. Servers are spawned lazily on the first real request
+    // (tools/call or a genuine tools-cache miss) so a server that is never
+    // called never holds a process. Set MCP_PREWARM_ON_BOOT=1 to restore the
+    // old prewarm-everything behavior.
+    if (process.env.MCP_PREWARM_ON_BOOT === "1") {
       const { mcpServerPool } = await import("./metamcp");
       await mcpServerPool.ensureIdleSessions(allServerParams);
       console.log(
-        "✅ Successfully initialized idle MCP server pool sessions for ALL servers",
+        "✅ Successfully initialized idle MCP server pool sessions for ALL servers (MCP_PREWARM_ON_BOOT=1)",
       );
     }
 
@@ -109,6 +125,11 @@ export async function initializeIdleServers() {
     console.log(
       "✅ Successfully initialized idle servers for all namespaces and all MCP servers",
     );
+
+    // Start the background tools-sync loop (keeps the `tools` table fresh so
+    // tools/list can be served from the DB). Non-blocking; runs off the request
+    // path entirely.
+    backgroundToolsSync.start();
   } catch (error) {
     console.log("❌ Error initializing idle servers:", error);
     // Don't exit the process, just log the error

--- a/apps/backend/src/lib/stdio-transport/cache-health.test.ts
+++ b/apps/backend/src/lib/stdio-transport/cache-health.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  // vi.hoisted factories run before ESM imports are initialized, so a dynamic
+  // require is the only way to get EventEmitter here (eslint: allowed).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("node:events");
+  const spawned: Array<{ cmd: string; args: string[] }> = [];
+  let exitCode = 0;
+  const defaultImpl = (
+    cmd: string,
+    args: string[],
+    _opts: unknown,
+  ): {
+    stdin: null;
+    stdout: NodeJS.EventEmitter;
+    stderr: NodeJS.EventEmitter;
+    emit: (e: string, code?: number) => void;
+  } => {
+    const proc = new EventEmitter() as {
+      stdin: null;
+      stdout: NodeJS.EventEmitter;
+      stderr: NodeJS.EventEmitter;
+      emit: (e: string, code?: number) => void;
+    };
+    proc.stdin = null;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    spawned.push({ cmd, args });
+    const code = exitCode;
+    setImmediate(() => proc.emit("close", code));
+    return proc;
+  };
+  return {
+    spawn: vi.fn(defaultImpl),
+    __defaultImpl: defaultImpl,
+    __spawned: spawned,
+    __setExitCode: (code: number) => {
+      exitCode = code;
+    },
+  };
+});
+
+vi.mock("node:child_process", () => ({
+  spawn: mockState.spawn,
+}));
+
+vi.mock("node:os", () => ({
+  homedir: () => "/home/test",
+}));
+
+// Capture rmSync calls instead of actually deleting anything (partial mock:
+// the logger still needs the rest of node:fs, e.g. createWriteStream).
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    rmSync: vi.fn(),
+  };
+});
+
+import { rmSync } from "node:fs";
+
+import {
+  cacheDirFor,
+  cacheKindForCommand,
+  maybeHealOnFastCrash,
+  resetHealedKindsForTest,
+  verifyAndHealNpmCache,
+} from "./cache-health";
+
+beforeEach(() => {
+  delete process.env.MCP_CACHE_HEAL;
+  delete process.env.MCP_CACHE_HEAL_FAST_FAIL_MS;
+  delete process.env.npm_config_cache;
+  delete process.env.UV_CACHE_DIR;
+  resetHealedKindsForTest();
+  mockState.spawn.mockClear();
+  mockState.spawn.mockImplementation(mockState.__defaultImpl);
+  mockState.__spawned.length = 0;
+  mockState.__setExitCode(0);
+  vi.mocked(rmSync).mockClear();
+});
+
+afterEach(() => {
+  return new Promise((resolve) => setTimeout(resolve, 20));
+});
+
+describe("cacheKindForCommand", () => {
+  it("classifies npx and npm as npm", () => {
+    expect(
+      cacheKindForCommand("npx -y @modelcontextprotocol/server-github"),
+    ).toBe("npm");
+    expect(cacheKindForCommand("npm exec --yes mcp-server-immich")).toBe("npm");
+  });
+
+  it("classifies uvx as uv", () => {
+    expect(cacheKindForCommand("uvx mcpo")).toBe("uv");
+  });
+
+  it("classifies bunx and bun as bun", () => {
+    expect(cacheKindForCommand("bunx @cyanheads/nws-weather-mcp-server")).toBe(
+      "bun",
+    );
+    expect(cacheKindForCommand("bun ./server.js")).toBe("bun");
+  });
+
+  it("returns undefined for unknown commands", () => {
+    expect(
+      cacheKindForCommand("/opt/pocket-id/pocket-id serve"),
+    ).toBeUndefined();
+    expect(cacheKindForCommand(undefined)).toBeUndefined();
+  });
+});
+
+describe("verifyAndHealNpmCache", () => {
+  it("does nothing when MCP_CACHE_HEAL is off", async () => {
+    mockState.__setExitCode(1);
+    expect(await verifyAndHealNpmCache()).toBe(false);
+    expect(vi.mocked(rmSync)).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on a clean verify", async () => {
+    process.env.MCP_CACHE_HEAL = "1";
+    mockState.__setExitCode(0);
+    expect(await verifyAndHealNpmCache()).toBe(false);
+    expect(vi.mocked(rmSync)).not.toHaveBeenCalled();
+    expect(mockState.__spawned[0]?.cmd).toBe("npm");
+    expect(mockState.__spawned[0]?.args).toEqual(["cache", "verify"]);
+  });
+
+  it("purges the npm cache when verify fails", async () => {
+    process.env.MCP_CACHE_HEAL = "1";
+    mockState.__setExitCode(1);
+    expect(await verifyAndHealNpmCache()).toBe(true);
+    expect(vi.mocked(rmSync)).toHaveBeenCalledWith(
+      expect.stringContaining(".npm"),
+      { recursive: true, force: true },
+    );
+  });
+});
+
+describe("maybeHealOnFastCrash", () => {
+  it("does nothing when MCP_CACHE_HEAL is off", () => {
+    expect(maybeHealOnFastCrash("npx -y foo", 1, 100)).toBe(false);
+    expect(vi.mocked(rmSync)).not.toHaveBeenCalled();
+  });
+
+  it("heals the npm cache on a fast non-zero exit", () => {
+    process.env.MCP_CACHE_HEAL = "1";
+    expect(
+      maybeHealOnFastCrash(
+        "npx -y @modelcontextprotocol/server-github",
+        1,
+        500,
+      ),
+    ).toBe(true);
+    expect(vi.mocked(rmSync)).toHaveBeenCalledWith(
+      expect.stringContaining(".npm"),
+      { recursive: true, force: true },
+    );
+  });
+
+  it("heals the uv cache for uvx", () => {
+    process.env.MCP_CACHE_HEAL = "1";
+    expect(maybeHealOnFastCrash("uvx mcpo", 1, 500)).toBe(true);
+    expect(vi.mocked(rmSync)).toHaveBeenCalledWith(
+      expect.stringContaining("uv"),
+      { recursive: true, force: true },
+    );
+  });
+
+  it("ignores exit 0, signal null, slow crashes, and unknown commands", () => {
+    process.env.MCP_CACHE_HEAL = "1";
+    expect(maybeHealOnFastCrash("npx -y foo", 0, 500)).toBe(false);
+    expect(maybeHealOnFastCrash("npx -y foo", null, 500)).toBe(false);
+    expect(maybeHealOnFastCrash("npx -y foo", 1, 60_000)).toBe(false);
+    expect(maybeHealOnFastCrash("/opt/pocket-id/pocket-id serve", 1, 100)).toBe(
+      false,
+    );
+    expect(vi.mocked(rmSync)).not.toHaveBeenCalled();
+  });
+
+  it("heals a given cache kind only once per process lifetime", () => {
+    process.env.MCP_CACHE_HEAL = "1";
+    expect(maybeHealOnFastCrash("npx -y foo", 1, 100)).toBe(true);
+    expect(maybeHealOnFastCrash("npx -y foo", 1, 100)).toBe(false);
+    expect(maybeHealOnFastCrash("npm exec foo", 1, 100)).toBe(false);
+    expect(maybeHealOnFastCrash("uvx foo", 1, 100)).toBe(true);
+    expect(vi.mocked(rmSync)).toHaveBeenCalledTimes(2);
+  });
+
+  it("respects the fast-fail window override", () => {
+    process.env.MCP_CACHE_HEAL = "1";
+    process.env.MCP_CACHE_HEAL_FAST_FAIL_MS = "2000";
+    expect(maybeHealOnFastCrash("npx -y foo", 1, 1500)).toBe(true);
+    resetHealedKindsForTest();
+    expect(maybeHealOnFastCrash("npx -y foo", 1, 2500)).toBe(false);
+  });
+
+  it("resolves cache dirs from npm_config_cache and UV_CACHE_DIR", () => {
+    process.env.npm_config_cache = "/custom/npm-cache";
+    process.env.UV_CACHE_DIR = "/custom/uv-cache";
+    expect(cacheDirFor("npm")).toBe("/custom/npm-cache");
+    expect(cacheDirFor("uv")).toBe("/custom/uv-cache");
+    expect(cacheDirFor("bun")).toBe("/home/test/.bun");
+  });
+});

--- a/apps/backend/src/lib/stdio-transport/cache-health.ts
+++ b/apps/backend/src/lib/stdio-transport/cache-health.ts
@@ -1,0 +1,197 @@
+import { spawn } from "node:child_process";
+import { rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import logger from "@/utils/logger";
+
+/**
+ * Self-healing for the per-user package caches that stdio MCP servers resolve
+ * their binaries from (`npx -y <pkg>` / `uvx <pkg>` / `bunx <pkg>`). Spawned
+ * servers inherit HOME (see DEFAULT_INHERITED_ENV_VARS) and no
+ * npm_config_cache / UV_CACHE_DIR override is applied, so every cold spawn
+ * writes the SAME cache dirs.
+ *
+ * npm's `_cacache` is NOT safe for concurrent writers. The pre-fix retry
+ * storm (5 retries × ~20 stdio servers) means several `npx` processes can be
+ * extracting the same entry at once → torn entries → "npx cache corrupted" /
+ * EINTEGRITY. Worse, the corruption is CASCADING: once an entry is corrupt,
+ * every spawn referencing it fails fast, each failure schedules another
+ * retry, and each retry is another concurrent writer. Two replicas sharing a
+ * persistent cache volume produces the same stomping by a second mechanism.
+ *
+ * This module breaks the cascade OPT-IN via MCP_CACHE_HEAL=1 (default off):
+ *   - prewarm verifies the npm cache and purges it when verification fails;
+ *   - a cold stdio spawn that crashes fast (non-zero exit well inside the
+ *     connect timeout) cleans the cache it uses ONCE per process lifetime,
+ *     so the pool's retry runs against a fresh cache instead of the corrupt
+ *     one.
+ *
+ * Nothing runs unless the operator opts in; a healthy warm cache is never
+ * touched.
+ */
+
+export type CacheKind = "npm" | "uv" | "bun";
+
+export const CACHE_DIRS: Record<
+  CacheKind,
+  { label: string; dir: () => string }
+> = {
+  npm: {
+    label: "npm",
+    dir: () => process.env.npm_config_cache ?? join(homedir(), ".npm"),
+  },
+  uv: {
+    label: "uv",
+    dir: () => process.env.UV_CACHE_DIR ?? join(homedir(), ".cache", "uv"),
+  },
+  bun: {
+    label: "bun",
+    dir: () => join(homedir(), ".bun"),
+  },
+};
+
+export function cacheDirFor(kind: CacheKind): string {
+  return CACHE_DIRS[kind].dir();
+}
+
+export function cacheHealingEnabled(): boolean {
+  const v = process.env.MCP_CACHE_HEAL?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+/** The fast-fail window: a stdio spawn that dies this quickly with a non-zero
+ * exit is failing on local resolution/extraction (corrupt cache, missing
+ * entry), not on a slow network download — a network timeout would surface as
+ * the connect timeout instead. */
+function fastFailMs(): number {
+  const raw = parseInt(process.env.MCP_CACHE_HEAL_FAST_FAIL_MS || "8000", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 8000;
+}
+
+/** Infer which package cache a server command resolves from. */
+export function cacheKindForCommand(
+  command: string | undefined,
+): CacheKind | undefined {
+  if (!command) {
+    return undefined;
+  }
+  const base = command.split(/\s+/)[0].toLowerCase();
+  if (/npx|node_modules[\\/]\.bin[\\/]/.test(command) || /^npm/.test(base)) {
+    return "npm";
+  }
+  if (/^uvx|^uv\b/.test(base)) {
+    return "uv";
+  }
+  if (/^bunx|^bun\b/.test(base)) {
+    return "bun";
+  }
+  return undefined;
+}
+
+/** Caches healed so far this process lifetime — a corrupt cache heals ONCE,
+ * never on every retry, so a genuinely broken server can't trigger a
+ * wipe-per-attempt loop. */
+const healedKinds = new Set<CacheKind>();
+
+export function healCacheKind(kind: CacheKind): boolean {
+  if (healedKinds.has(kind)) {
+    return false;
+  }
+  const dir = cacheDirFor(kind);
+  try {
+    rmSync(dir, { recursive: true, force: true });
+    healedKinds.add(kind);
+    logger.warn(
+      `[cache-health] removed ${CACHE_DIRS[kind].label} cache at ${dir} — the pool will rebuild it on the next spawn.`,
+    );
+    return true;
+  } catch (error) {
+    logger.error(
+      `[cache-health] failed to remove ${CACHE_DIRS[kind].label} cache at ${dir}:`,
+      error,
+    );
+    return false;
+  }
+}
+
+function runCapture(
+  command: string,
+  args: string[],
+): Promise<{ code: number; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      env: { ...process.env },
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+    });
+    let output = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({ code: -1, output: String(error) });
+    });
+    child.on("close", (code) => {
+      resolve({ code: code ?? -1, output });
+    });
+  });
+}
+
+/** `npm cache verify` is the corruption DETECTOR + self-healer for the
+ * `_cacache` store: it re-checks every entry and removes the corrupt ones. A
+ * non-zero exit (or a verify error in the output) means it could not fully
+ * verify — the store is bad enough that a full purge is the reliable fix. */
+export async function verifyAndHealNpmCache(): Promise<boolean> {
+  if (!cacheHealingEnabled()) {
+    return false;
+  }
+  const result = await runCapture("npm", ["cache", "verify"]);
+  const suspicious =
+    /verify|integrity|corrupt|index/i.test(result.output) &&
+    /error|fail/i.test(result.output);
+  if (result.code === 0 && !suspicious) {
+    logger.info(
+      `[cache-health] npm cache verified clean (${result.output.trim().slice(0, 200) || "ok"})`,
+    );
+    return false;
+  }
+  logger.warn(
+    `[cache-health] npm cache verify reported problems (${result.code}) — ${result.output.trim().slice(0, 300) || "no output"}. Purging the npm cache so prewarm/spawns rebuild it.`,
+  );
+  return healCacheKind("npm");
+}
+
+/**
+ * Call from a stdio spawn that died fast with a non-zero exit. Cleans the
+ * cache the command resolves from once per process lifetime, so the pool's
+ * next retry runs on a fresh cache instead of the corrupt one.
+ */
+export function maybeHealOnFastCrash(
+  command: string | undefined,
+  exitCode: number | null,
+  elapsedMs: number,
+): boolean {
+  if (!cacheHealingEnabled()) {
+    return false;
+  }
+  if (exitCode === 0 || exitCode === null) {
+    return false;
+  }
+  if (elapsedMs > fastFailMs()) {
+    return false;
+  }
+  const kind = cacheKindForCommand(command);
+  if (!kind) {
+    return false;
+  }
+  return healCacheKind(kind);
+}
+
+/** For tests. */
+export function resetHealedKindsForTest(): void {
+  healedKinds.clear();
+}

--- a/apps/backend/src/lib/stdio-transport/prewarm.test.ts
+++ b/apps/backend/src/lib/stdio-transport/prewarm.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  // vi.hoisted factories run before ESM imports are initialized, so a dynamic
+  // require is the only way to get EventEmitter here (eslint: allowed).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("node:events");
+  const spawned: Array<{
+    cmd: string;
+    args: string[];
+    proc: {
+      stdin: null;
+      stdout: NodeJS.EventEmitter;
+      stderr: NodeJS.EventEmitter;
+      emit: (e: string, code?: number) => void;
+    };
+  }> = [];
+  let exitCode = 0;
+  // The REAL default implementation — record every spawn with its args and
+  // close with the exit code captured AT SPAWN TIME on the next tick. Tests
+  // that swap in a custom mockImplementation restore this in `beforeEach`.
+  const defaultImpl = (
+    cmd: string,
+    args: string[],
+    _opts: unknown,
+  ): {
+    stdin: null;
+    stdout: NodeJS.EventEmitter;
+    stderr: NodeJS.EventEmitter;
+    emit: (e: string, code?: number) => void;
+  } => {
+    const proc = new EventEmitter() as {
+      stdin: null;
+      stdout: NodeJS.EventEmitter;
+      stderr: NodeJS.EventEmitter;
+      emit: (e: string, code?: number) => void;
+    };
+    proc.stdin = null;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    spawned.push({ cmd, args, proc });
+    const code = exitCode;
+    setImmediate(() => proc.emit("close", code));
+    return proc;
+  };
+  return {
+    spawn: vi.fn(defaultImpl),
+    __defaultImpl: defaultImpl,
+    __spawned: spawned,
+    __setExitCode: (code: number) => {
+      exitCode = code;
+    },
+  };
+});
+
+vi.mock("node:child_process", () => ({
+  spawn: mockState.spawn,
+}));
+
+vi.mock("node:os", () => ({
+  homedir: () => "/home/test",
+}));
+
+// Never delete a real cache during tests (partial mock: the logger still
+// needs the rest of node:fs, e.g. createWriteStream).
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    rmSync: vi.fn(),
+  };
+});
+
+import { rmSync } from "node:fs";
+
+import { resetHealedKindsForTest } from "./cache-health";
+import { startRuntimePrewarm } from "./prewarm";
+
+beforeEach(() => {
+  delete process.env.MCP_PREWARM_NPM;
+  delete process.env.MCP_PREWARM_UVX;
+  delete process.env.MCP_PREWARM_BUN;
+  delete process.env.MCP_PREWARM_CONCURRENCY;
+  delete process.env.MCP_PREWARM_NPM_CMD;
+  delete process.env.MCP_PREWARM_UVX_CMD;
+  delete process.env.MCP_PREWARM_BUN_CMD;
+  delete process.env.MCP_CACHE_HEAL;
+  delete process.env.MCP_CACHE_HEAL_FAST_FAIL_MS;
+  resetHealedKindsForTest();
+  vi.mocked(rmSync).mockClear();
+  // mockReset (not just mockClear) also drops any unconsumed
+  // mockImplementationOnce queue from a prior test, then restore the real
+  // implementation — a custom mockImplementation must not leak here.
+  mockState.spawn.mockReset();
+  mockState.spawn.mockImplementation(mockState.__defaultImpl);
+  mockState.__spawned.length = 0;
+  mockState.__setExitCode(0);
+});
+
+afterEach(() => {
+  return new Promise((resolve) => setTimeout(resolve, 20));
+});
+
+describe("startRuntimePrewarm", () => {
+  it("skips when no MCP_PREWARM_* packages are configured", () => {
+    startRuntimePrewarm();
+    expect(mockState.spawn).not.toHaveBeenCalled();
+  });
+
+  it("installs configured npm packages one at a time", async () => {
+    process.env.MCP_PREWARM_NPM = "pkg-a pkg-b";
+    startRuntimePrewarm();
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const installs = mockState.__spawned.filter((s) => s.args[0] === "install");
+    // One spawn per package (not a single batch) so one bad package can't
+    // abort the whole list (npm 10 exits 243 on a single engine violation).
+    expect(installs.map((s) => s.args)).toEqual([
+      ["install", "-g", "pkg-a"],
+      ["install", "-g", "pkg-b"],
+    ]);
+    expect(installs.every((s) => s.cmd === "npm")).toBe(true);
+  });
+
+  it("honors the custom command env (MCP_PREWARM_NPM_CMD)", async () => {
+    process.env.MCP_PREWARM_NPM = "pkg-a";
+    process.env.MCP_PREWARM_NPM_CMD = "/usr/local/bin/my-npm";
+    startRuntimePrewarm();
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const npmSpawn = mockState.__spawned.find((s) => s.args[0] === "install");
+    expect(npmSpawn?.cmd).toBe("/usr/local/bin/my-npm");
+  });
+
+  it("a failing package does not block the other packages (per-package isolation)", async () => {
+    process.env.MCP_PREWARM_NPM = "pkg-a pkg-b pkg-c";
+
+    // pkg-b fails (close 1); the real impl closes 0 for the others.
+    let failNext = false;
+    const originalImpl = mockState.spawn.getMockImplementation();
+    mockState.spawn.mockImplementation((cmd, args, opts) => {
+      if (!originalImpl) {
+        throw new Error("expected the real spawn implementation");
+      }
+      const proc = originalImpl(cmd, args, opts);
+      if (args[2] === "pkg-b") {
+        failNext = true;
+      }
+      if (failNext) {
+        failNext = false;
+        process.nextTick(() => proc.emit("close", 1));
+      }
+      return proc;
+    });
+
+    startRuntimePrewarm();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // All three packages were attempted despite pkg-b failing.
+    const installs = mockState.__spawned.filter((s) => s.args[0] === "install");
+    expect(installs.map((s) => s.args[2])).toEqual(["pkg-a", "pkg-b", "pkg-c"]);
+    // The failing pkg-b was attempted exactly once (no whole-group retry
+    // without MCP_CACHE_HEAL).
+    expect(installs.filter((s) => s.args[2] === "pkg-b").length).toBe(1);
+  });
+
+  it("does not exceed MCP_PREWARM_CONCURRENCY concurrent spawns", async () => {
+    process.env.MCP_PREWARM_NPM = "pkg-a";
+    process.env.MCP_PREWARM_UVX = "uvx-a";
+    process.env.MCP_PREWARM_BUN = "bun-a";
+    process.env.MCP_PREWARM_CONCURRENCY = "2";
+
+    // Block ALL workers: replace the mock so every spawned process never
+    // emits `close`, so no worker finishes while we observe concurrency.
+    mockState.spawn.mockImplementation(() => {
+      // Same `require` caveat as the hoisted factory.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const EventEmitter = require("node:events").EventEmitter;
+      const emitter = new EventEmitter() as {
+        stdin: null;
+        stdout: NodeJS.EventEmitter;
+        stderr: NodeJS.EventEmitter;
+        emit: (e: string, code?: number) => void;
+      };
+      emitter.stdin = null;
+      emitter.stdout = new EventEmitter();
+      emitter.stderr = new EventEmitter();
+      // Push to __spawned so we count the attempts, but never emit close.
+      mockState.__spawned.push({ cmd: "blocked", args: [], proc: emitter });
+      return emitter;
+    });
+
+    startRuntimePrewarm();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // 3 configured groups, concurrency 2 → at most 2 spawns fire.
+    expect(mockState.__spawned.length).toBeLessThanOrEqual(2);
+  });
+
+  it("continues when an installer fails (does not throw)", async () => {
+    process.env.MCP_PREWARM_NPM = "pkg-a";
+    process.env.MCP_PREWARM_UVX = "uvx-a";
+    process.env.MCP_PREWARM_CONCURRENCY = "1";
+
+    // The real mock pushes every spawn with its args and emits close with the
+    // exit code on the next tick. Make the FIRST spawned group (npm) fail by
+    // emitting close(1) on process.nextTick — which fires BEFORE the real
+    // impl's setImmediate close(0), so `run` deterministically resolves 1.
+    let first = true;
+    const originalImpl = mockState.spawn.getMockImplementation();
+    mockState.spawn.mockImplementation((cmd, args, opts) => {
+      if (!originalImpl) {
+        throw new Error("expected the real spawn implementation");
+      }
+      const proc = originalImpl(cmd, args, opts);
+      if (first) {
+        first = false;
+        process.nextTick(() => proc.emit("close", 1));
+      }
+      return proc;
+    });
+
+    startRuntimePrewarm();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Both groups attempted despite the first failing (npm install + uvx tool).
+    expect(mockState.__spawned.some((s) => s.args[0] === "install")).toBe(true);
+    expect(mockState.__spawned.some((s) => s.args[0] === "tool")).toBe(true);
+  });
+
+  it("with MCP_CACHE_HEAL: purges the cache and retries once when the npm install fails", async () => {
+    process.env.MCP_PREWARM_NPM = "pkg-a";
+    process.env.MCP_CACHE_HEAL = "1";
+
+    // Spawn sequence: (1) `npm cache verify` clean → no preemptive purge;
+    // (2) `npm install -g pkg-a` FAILS → group retry heals the cache;
+    // (3) retry install SUCCEEDS against the fresh store (default impl).
+    mockState.spawn.mockImplementationOnce(() => {
+      const proc = mockState.__defaultImpl("npm", ["cache", "verify"], {});
+      return proc;
+    });
+    mockState.spawn.mockImplementationOnce(() => {
+      const proc = mockState.__defaultImpl(
+        "npm",
+        ["install", "-g", "pkg-a"],
+        {},
+      );
+      // First install fails.
+      process.nextTick(() => proc.emit("close", 1));
+      return proc;
+    });
+
+    startRuntimePrewarm();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const installs = mockState.__spawned.filter(
+      (s) => s.cmd === "npm" && s.args[0] === "install",
+    );
+    // The retry happened (2 install spawns total).
+    expect(installs.length).toBe(2);
+    // The corrupt cache was purged exactly once between the two installs.
+    expect(vi.mocked(rmSync)).toHaveBeenCalledWith(
+      expect.stringContaining(".npm"),
+      { recursive: true, force: true },
+    );
+  });
+
+  it("without MCP_CACHE_HEAL: a failed install is NOT retried and the cache is not purged", async () => {
+    process.env.MCP_PREWARM_NPM = "pkg-a";
+
+    mockState.spawn.mockImplementationOnce(() => {
+      const proc = mockState.__defaultImpl(
+        "npm",
+        ["install", "-g", "pkg-a"],
+        {},
+      );
+      process.nextTick(() => proc.emit("close", 1));
+      return proc;
+    });
+
+    startRuntimePrewarm();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const installs = mockState.__spawned.filter(
+      (s) => s.cmd === "npm" && s.args[0] === "install",
+    );
+    expect(installs.length).toBe(1);
+    expect(vi.mocked(rmSync)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/lib/stdio-transport/prewarm.ts
+++ b/apps/backend/src/lib/stdio-transport/prewarm.ts
@@ -1,0 +1,269 @@
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+
+import logger from "@/utils/logger";
+
+import {
+  cacheHealingEnabled,
+  type CacheKind,
+  healCacheKind,
+  verifyAndHealNpmCache,
+} from "./cache-health";
+
+/**
+ * Runtime prewarm for stdio MCP servers that install their package on first
+ * spawn (npx -y / uvx / bunx). A cold spawn that has to download a large
+ * package (30-60s+) blows past the connect timeout during a container
+ * create/boot, when ~20 stdio servers all spawn at once.
+ *
+ * The operator opts in by setting environment variables; nothing is baked
+ * into the image:
+ *
+ *   MCP_PREWARM_NPM="pkg1 pkg2"     # npm install -g (npx falls back to the
+ *                                   #   global install, so `npx -y pkg1` no
+ *                                   #   longer re-downloads)
+ *   MCP_PREWARM_UVX="uvxpkg1 uvxpkg2"  # uv tool install (uvx resolves from
+ *                                   #   ~/.cache/uv)
+ *   MCP_PREWARM_BUN="bunpkg1"       # bun add -g (bunx resolves from the
+ *                                   #   global bun cache)
+ *   MCP_PREWARM_CONCURRENCY=2       # how many package managers to prewarm at
+ *                                   #   once (default 2)
+ *
+ * Prewarm targets the standard per-user cache dirs, so it also pairs with a
+ * persistent volume mounted on those dirs (e.g. /home/nextjs/.npm,
+ * /home/nextjs/.cache/uv) to survive container recreates.
+ */
+
+function parseList(envValue: string | undefined): string[] {
+  if (!envValue) {
+    return [];
+  }
+  return envValue
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function run(
+  command: string,
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ code: number; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+    });
+    let output = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({ code: -1, output: String(error) });
+    });
+    child.on("close", (code) => {
+      resolve({ code: code ?? -1, output });
+    });
+  });
+}
+
+/**
+ * Prewarm packages ONE AT A TIME. A single package that fails (engine
+ * mismatch — npm 10 aborts a whole batch install with exit 243 on one
+ * `engines.node` violation — a bad build, a transient registry error) must
+ * not block the rest of the list. Each package installs or logs its own
+ * warning; the pool still falls back to on-demand spawn for the failures.
+ *
+ * Cache self-heal still applies at the GROUP level: the npm cache is verified
+ * before the group starts, and if the whole group comes back failing (a
+ * corrupt store), the cache is purged once and the group retried once.
+ */
+async function prewarmWith(
+  label: string,
+  defaultCommand: string,
+  commandEnv: string,
+  kind: CacheKind,
+  args: string[],
+  packages: string[],
+): Promise<void> {
+  if (packages.length === 0) {
+    return;
+  }
+  // The env var (commandEnv) is an optional override; defaultCommand is the
+  // real binary name (npm / uvx / bun) when it isn't set.
+  const cmd = process.env[commandEnv] || defaultCommand;
+
+  const installOne = async (pkg: string): Promise<number> => {
+    // args is the "shape" of the install command per package manager, e.g.
+    // ["install", "-g"] for npm — the package name is appended per install.
+    //
+    // npm: install into a USER-WRITABLE prefix. Images built from the official
+    // node image (or deb.nodesource) ship an npm global prefix of /usr, which
+    // is root-owned — a runtime prewarm running as the app user would hit
+    // EACCES mkdir /usr/lib/node_modules. npx -y resolves its fallback global
+    // install from npm_config_prefix, so pointing it at a writable prefix both
+    // fixes the install AND makes on-demand spawns actually reuse it.
+    const runEnv: Record<string, string> = { npm_config_yes: "true" };
+    if (kind === "npm") {
+      // See the comment above: install into a user-writable prefix so a runtime
+      // prewarm running as a non-root user doesn't hit EACCES on /usr, and npx
+      // can reuse the warm on spawn.
+      runEnv.npm_config_prefix =
+        process.env.MCP_PREWARM_NPM_PREFIX || `${homedir()}/.npm-global`;
+    }
+    const result = await run(cmd, [...args, pkg], runEnv);
+    if (result.code === 0) {
+      logger.info(
+        `[prewarm] ${label}: pre-installed ${pkg} (${result.output.trim().slice(0, 200) || "ok"})`,
+      );
+    } else {
+      logger.warn(
+        `[prewarm] ${label}: failed to pre-install ${pkg} (${result.code}) — ${result.output.trim().slice(0, 300) || "no output"}. Spawns will fall back to on-demand install.`,
+      );
+    }
+    return result.code;
+  };
+
+  if (kind === "npm" && cacheHealingEnabled()) {
+    // npm's cache verify is the corruption detector; purge when it fails so
+    // the installs below start from a clean store (avoids re-installing on
+    // top of a corrupt entry).
+    await verifyAndHealNpmCache();
+  }
+
+  // Pass 1 — install each package individually.
+  const results = [];
+  for (const pkg of packages) {
+    results.push(await installOne(pkg));
+    // uvx: `uv tool install <pkg>` only works when the package ships an
+    // executable named exactly <pkg> (postgres-mcp, jupyter-mcp-server, ... do
+    // NOT — they are module-runners invoked via `uvx <pkg>` with a different
+    // bin). For those, fall back to a `uvx <pkg> --help` warm: it pulls the
+    // wheel into ~/.cache/uv (the same store uvx resolves on spawn) without
+    // installing a tool. Keep the per-package isolation — a failing fallback
+    // logs its own warning and does not block the rest.
+    if (kind === "uv" && results[results.length - 1] !== 0) {
+      const warmResult = await run(
+        process.env.MCP_PREWARM_UVX_CMD || "uvx",
+        [pkg, "--help"],
+        { npm_config_yes: "true" },
+      );
+      if (warmResult.code === 0) {
+        logger.info(
+          `[prewarm] uvx: warmed ${pkg} cache via uvx --help (no executable tool; ${warmResult.output.trim().slice(0, 200) || "ok"})`,
+        );
+        results[results.length - 1] = 0;
+      } else {
+        logger.warn(
+          `[prewarm] uvx: cache-warm fallback failed for ${pkg} (${warmResult.code}) — ${warmResult.output.trim().slice(0, 300) || "no output"}. Spawns will fall back to on-demand uvx.`,
+        );
+      }
+    }
+  }
+
+  // Pass 2 — if EVERY package failed AND the cache could be corrupt, purge it
+  // once and retry the whole group once against the fresh store. Per-package
+  // transient failures (one bad engine, one bad build) already logged their
+  // warning in pass 1 and are NOT retried here.
+  const allFailed = results.length > 0 && results.every((c) => c !== 0);
+  if (allFailed && cacheHealingEnabled() && healCacheKind(kind)) {
+    logger.warn(
+      `[prewarm] ${label}: all ${packages.length} pre-installs failed; purged ${kind} cache, retrying group once.`,
+    );
+    for (const pkg of packages) {
+      await installOne(pkg);
+    }
+  }
+}
+
+/**
+ * Kick off the configured prewarm in the background (fire-and-forget).
+ * Uses `npm install -g` / `uv tool install` / `bun add -g` so the packages
+ * land in the user-level caches npx/uvx/bunx resolve from. Bounded to
+ * MCP_PREWARM_CONCURRENCY package managers at once so a cold boot doesn't
+ * spawn three heavy installers simultaneously.
+ */
+export function startRuntimePrewarm(): void {
+  const npmPackages = parseList(process.env.MCP_PREWARM_NPM);
+  const uvxPackages = parseList(process.env.MCP_PREWARM_UVX);
+  const bunPackages = parseList(process.env.MCP_PREWARM_BUN);
+
+  if (npmPackages.length + uvxPackages.length + bunPackages.length === 0) {
+    logger.info(
+      "[prewarm] no MCP_PREWARM_* packages configured; skipping runtime prewarm",
+    );
+    return;
+  }
+
+  const concurrency = parseInt(process.env.MCP_PREWARM_CONCURRENCY || "2", 10);
+  logger.info(
+    `[prewarm] starting runtime prewarm: npm(${npmPackages.length}) uvx(${uvxPackages.length}) bun(${bunPackages.length}) concurrency=${concurrency}`,
+  );
+
+  const tasks: Array<() => Promise<void>> = [];
+  if (npmPackages.length > 0) {
+    tasks.push(() =>
+      prewarmWith(
+        "npm",
+        "npm",
+        "MCP_PREWARM_NPM_CMD",
+        "npm",
+        ["install", "-g"],
+        npmPackages,
+      ),
+    );
+  }
+  if (uvxPackages.length > 0) {
+    tasks.push(() =>
+      prewarmWith(
+        "uvx",
+        "uvx",
+        "MCP_PREWARM_UVX_CMD",
+        "uv",
+        ["tool", "install"],
+        uvxPackages,
+      ),
+    );
+  }
+  if (bunPackages.length > 0) {
+    tasks.push(() =>
+      prewarmWith(
+        "bun",
+        "bun",
+        "MCP_PREWARM_BUN_CMD",
+        "bun",
+        ["add", "-g"],
+        bunPackages,
+      ),
+    );
+  }
+
+  // Bounded: a strict worker pool of `concurrency` installers. Each worker
+  // pulls the next task only after the previous one finishes, so the number
+  // of concurrent installers never exceeds `concurrency` (a naive
+  // `.finally(runNext)` re-entry can overshoot while a sibling is still
+  // running).
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < tasks.length) {
+      const task = tasks[next];
+      next += 1;
+      try {
+        await task();
+      } catch (error) {
+        // startRuntimePrewarm is fire-and-forget; a throwing installer must
+        // not crash the process or stop the remaining workers.
+        logger.error("[prewarm] unexpected prewarm task failure:", error);
+      }
+    }
+  };
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < concurrency && i < tasks.length; i += 1) {
+    workers.push(worker());
+  }
+  void Promise.allSettled(workers);
+}

--- a/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
+++ b/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
@@ -8,6 +8,7 @@ import spawn from "cross-spawn";
 
 import logger from "@/utils/logger";
 
+import { maybeHealOnFastCrash } from "./cache-health";
 import { ReadBuffer, serializeMessage } from "./shared";
 
 export type StdioServerParameters = {
@@ -110,6 +111,19 @@ export function getDefaultEnvironment(): Record<string, string> {
     env[key] = value;
   }
 
+  // Always append the runtime's own bin dirs to PATH so tools installed at
+  // the system level (bun/bunx, global npx packages) resolve for spawned
+  // servers. In the Docker image the runtime runs as `USER nextjs`, whose
+  // non-login shells do not read ~/.bashrc, so a $HOME-based install would
+  // be unreachable by spawned processes — the image installs bun under
+  // /usr/local precisely so this appending finds it.
+  const inheritedPath = env["PATH"] ?? process.env.PATH ?? "";
+  const ownBinDir = process.execPath.replace(/\/[^/]+$/, "");
+  const extraDirs = ["/usr/local/bin", "/usr/bin", "/bin", ownBinDir];
+  env["PATH"] = [...new Set([...extraDirs, ...inheritedPath.split(":")])]
+    .filter(Boolean)
+    .join(":");
+
   return env;
 }
 
@@ -125,6 +139,7 @@ export class ProcessManagedStdioTransport implements Transport {
   private _serverParams: StdioServerParameters;
   private _stderrStream: PassThrough | null = null;
   private _isCleanup: boolean = false;
+  private _spawnedAt: number | null = null;
 
   onclose?: () => void;
   onerror?: (error: Error) => void;
@@ -149,6 +164,7 @@ export class ProcessManagedStdioTransport implements Transport {
     }
 
     return new Promise((resolve, reject) => {
+      this._spawnedAt = Date.now();
       this._process = spawn(
         this._serverParams.command,
         this._serverParams.args ?? [],
@@ -192,6 +208,16 @@ export class ProcessManagedStdioTransport implements Transport {
         // Only emit crash event if this wasn't a clean shutdown
         if (!this._isCleanup && (code !== 0 || signal)) {
           logger.warn(`Process crashed with code: ${code}, signal: ${signal}`);
+          // A stdio server that dies fast with a non-zero exit (long before
+          // the connect timeout) is failing on local cache resolution —
+          // "npx cache corrupted" etc. With MCP_CACHE_HEAL=1, purge the cache
+          // it resolves from so the pool's retry runs against a fresh store
+          // instead of a corrupt one. Healthy warm caches are never touched.
+          maybeHealOnFastCrash(
+            this._serverParams.command,
+            code,
+            Date.now() - (this._spawnedAt ?? Date.now()),
+          );
           logger.info(
             `Calling onprocesscrash handler: ${this.onprocesscrash ? "handler exists" : "no handler"}`,
           );

--- a/apps/backend/src/routers/mcp-proxy/metamcp.ts
+++ b/apps/backend/src/routers/mcp-proxy/metamcp.ts
@@ -256,10 +256,12 @@ metamcpRouter.post("/:uuid/message", async (req, res) => {
   }
 });
 
-metamcpRouter.get("/health", (req, res) => {
+metamcpRouter.get("/health", async (req, res) => {
+  const poolDebug = await mcpServerPool.getDebugInfo();
   res.json({
     status: "ok",
     service: "metamcp",
+    pool: poolDebug,
   });
 });
 

--- a/apps/backend/src/routers/public-metamcp.ts
+++ b/apps/backend/src/routers/public-metamcp.ts
@@ -4,6 +4,7 @@ import express from "express";
 import logger from "@/utils/logger";
 
 import { endpointsRepository } from "../db/repositories/endpoints.repo";
+import { mcpServerPool } from "../lib/metamcp/mcp-server-pool";
 import adminRouter from "./public-metamcp/admin";
 import { openApiRouter } from "./public-metamcp/openapi";
 import sseRouter from "./public-metamcp/sse";
@@ -48,10 +49,12 @@ publicEndpointsRouter.use(openApiRouter);
 publicEndpointsRouter.use(adminRouter);
 
 // Health check endpoint
-publicEndpointsRouter.get("/health", (req, res) => {
+publicEndpointsRouter.get("/health", async (req, res) => {
+  const poolDebug = await mcpServerPool.getDebugInfo();
   res.json({
     status: "ok",
     service: "public-endpoints",
+    pool: poolDebug,
   });
 });
 

--- a/apps/backend/src/routers/public-metamcp/streamable-http.ts
+++ b/apps/backend/src/routers/public-metamcp/streamable-http.ts
@@ -13,6 +13,7 @@ import logger from "@/utils/logger";
 
 import { buildAdminToolsOptions } from "../../lib/admin-mcp/build-admin-tools-options";
 import { extractClientHeaders } from "../../lib/metamcp/header-forwarding";
+import { mcpServerPool } from "../../lib/metamcp/mcp-server-pool";
 import { MetaMCPHandlerContext } from "../../lib/metamcp/metamcp-middleware/functional-middleware";
 import { metaMcpServerPool } from "../../lib/metamcp/metamcp-server-pool";
 import { SessionLifetimeManagerImpl } from "../../lib/session-lifetime-manager";
@@ -101,9 +102,10 @@ const cleanupSession = async (
 };
 
 // Health check endpoint to monitor sessions
-streamableHttpRouter.get("/health/sessions", (req, res) => {
+streamableHttpRouter.get("/health/sessions", async (req, res) => {
   const sessionIds = sessionManager.getSessionIds();
   const poolStatus = metaMcpServerPool.getPoolStatus();
+  const poolDebug = await mcpServerPool.getDebugInfo();
 
   res.json({
     timestamp: new Date().toISOString(),
@@ -112,6 +114,7 @@ streamableHttpRouter.get("/health/sessions", (req, res) => {
       sessionIds: sessionIds,
     },
     metaMcpPoolStatus: poolStatus,
+    poolDebug,
     totalActiveSessions: sessionIds.length + poolStatus.active,
   });
 });


### PR DESCRIPTION
Backend-only consolidation (no Dockerfile/workflow/lockfile changes — the fold's mirror-main owns those, so this folds cleanly):

- runtime package prewarm (npm/uvx/bun) + cache self-heal
- never spawn MCPs when unused (health-loop rewrite, Fix 1)
- recovery cooldown + circuit-breaker bound on session-lost (Fix 2)
- CallToolResult normalize before SDK validation (Fix 3, -32602)
- clean up leaked fresh spawn when a recovery retry fails (memory leak)
- DB tools/list serving + circuit-open surfacing + quiet DEBUG logging

Typecheck clean, 218 tests pass. Folds cleanly vs ai-dev.