### PR TITLE
fix(docker): make the Next.js proxy-request sed path-agnostic + fail-open

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+# Canonical intarweb build workflow — the ONLY workflow a repo needs to produce
+# ghcr.io/intarweb/<repo>:latest. No logic here: everything (fork sync, PR
+# folding, fingerprint/no-op, build) lives in the shared workflow it calls.
+# This file is identical in every repo by construction — operations' build step
+# re-asserts this exact copy onto a fork's mirror main after every sync.
+#
+#   FORK:       main is synced to the upstream default branch; every open
+#               intarweb→upstream PR is folded into the built image. Rebuilds
+#               when our PRs update, a PR is opened against the fork, or
+#               upstream moves (see schedule).
+#   GREENFIELD: every push to the default branch builds :latest.
+# Shared logic: intarweb/operations/.github/workflows/build.yml (public repo —
+# reusable workflows resolve + unlimited Actions minutes).
+
+name: build
+
+on:
+  push:                    # any branch push — a push to a branch that heads an
+                           # upstream PR fires instantly when build.yml is seeded
+                           # on it (GH uses the branch's own workflow file).
+  pull_request:            # PRs opened AGAINST the fork (fork-internal PRs)
+  schedule:
+    # Low-cadence re-sync only (no poll). GitHub fires NO event on the fork
+    # when an intarweb->upstream PR is opened, so this is what keeps the fork
+    # main mirrored to upstream, re-arms the seed onto PR branches that a
+    # rebase dropped it from, and folds newly-opened PRs. The instant path is
+    # `push` above.
+    - cron: '4 4 * * *'    # daily upstream re-sync + seed re-arm + fold (~4 AM local)
+  workflow_dispatch:
+
+permissions:
+  contents: write   # shared workflow re-applies this overlay on fork mirror main
+  packages: write   # GHCR push
+
+jobs:
+  publish:
+    uses: intarweb/operations/.github/workflows/build.yml@main
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,8 +97,11 @@ ENV CI=true
 # Install production dependencies only
 RUN pnpm install --prod
 
-# Install drizzle-kit locally in backend for migrations
-RUN cd apps/backend && pnpm add drizzle-kit@0.31.1
+# Install drizzle-kit locally in backend for migrations. Must be a PROD dep:
+# the modules dir above was installed with --prod (dependencies only), so a
+# devDependency add would trip ERR_PNPM_INCLUDED_DEPS_CONFLICT (different
+# included-deps set). --prod keeps both operations targeting dependencies.
+RUN cd apps/backend && pnpm add --prod drizzle-kit@0.31.1
 
 # Copy startup script
 COPY --chown=nextjs:nodejs docker-entrypoint.sh ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/package.json ./
 COPY --from=builder --chown=nextjs:nodejs /app/pnpm-workspace.yaml ./
 
+# pnpm aborts the modules-dir removal when there's no TTY unless CI is set; CI builds are non-TTY.
+ENV CI=true
+
 # Install production dependencies only
 RUN pnpm install --prod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,14 @@ COPY . .
 # Build all packages and apps
 RUN pnpm build
 
-RUN sed -i -e "s/30000/600000/" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/server/lib/router-utils/proxy-request.js" \
-    "node_modules/.pnpm/next@15.5.12_react-dom@19.1.2_react@19.1.2__react@19.1.2/node_modules/next/dist/esm/server/lib/router-utils/proxy-request.js"
+# Bump Next.js dev proxy timeout 30s -> 600s. The pnpm store dir for `next`
+# embeds the resolved react/react-dom versions, so glob it instead of
+# hardcoding — a hardcoded path silently breaks on every react/next bump
+# (observed: react-dom@19.1.2 in the lockfile vs 19.2.4 in the glob) and a
+# failing sed aborts the whole image build. Fail-open so a missing file can
+# never brick :latest.
+RUN find node_modules/.pnpm -path "*next/dist/server/lib/router-utils/proxy-request.js" -exec sed -i "s/30000/600000/" {} + || true && \
+    find node_modules/.pnpm -path "*next/dist/esm/server/lib/router-utils/proxy-request.js" -exec sed -i "s/30000/600000/" {} + || true
 
 # Production runner stage
 FROM base AS runner


### PR DESCRIPTION
The proxy-request timeout bump hardcodes the pnpm store path for `next@15.5.12` with `react-dom@19.1.2`, but the lockfile can resolve a different react-dom (19.2.4) after a bump — the sed then targets a nonexistent file and exits 2, aborting the entire image build and failing :latest for every repo folded through the fork. Glob the store dir with `find` and fail-open so the timeout patch survives any dependency bump and a missing file can never brick the build.